### PR TITLE
fix: Kiwi domain misread as logical database (permission error)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ DATAZEN_PLUGINS=all pnpm tauri:build   # 全部插件打包
 - **零硬编码**：行为差异通过 `DB_REGISTRY` + `DatabaseTypeMeta` 元数据驱动
 - **表单路由**：`ConnectionFormBody.tsx` 通过 `connectionForm` 字段选择表单组件
 - **视图路由**：`connectionViews/index.ts` 映射 `connectionMode` → 视图组件
-- **多库会话**：`hasMultiDatabase` 为驱动能力；未配置 `database` 时列出全部可见库（`MultiDatabaseSchemaTree`）；配置了 `database` 时锁定单库（`StandardSchemaTree`）。会话 `isMultiDatabase = hasMultiDatabase && 可见库数量 > 1`；切库走 `use_database`（MySQL/MariaDB/PostgreSQL）
+- **多库会话**：`hasMultiDatabase` 为驱动能力；未配置逻辑库时列出全部可见库（`MultiDatabaseSchemaTree`）；配置了**逻辑库名**（且出现在 `get_databases` 列表）时锁定单库。Kiwi 的 `database` 字段是实例 **domain**（`databaseFieldType: 'domain'`），不参与锁定。会话 `isMultiDatabase = hasMultiDatabase && 可见库数量 > 1`；切库走 `use_database`
 - **多窗口**：`windowManager.ts` + `windowKind.ts` URL 参数路由，`App.tsx` 按 kind 懒加载
 - **IPC 约定**：前端 `invoke()` 传参使用 `snake_case` key 与后端对齐
 

--- a/docs/architecture/frontend/extensibility.md
+++ b/docs/architecture/frontend/extensibility.md
@@ -44,7 +44,8 @@ src/windows/connection/
 | `connectionView` | 路由到 `CONNECTION_VIEWS`（sql / keyvalue / document） |
 | `connectionForm` | 路由到连接表单 Fields 组件（standard / kiwi / file / index） |
 | `sqlDialect` | 路由到 `sqlDialects/` 策略 |
-| `hasMultiDatabase` | 驱动**能力**标志。未配置连接 `database` 时 `SchemaTree` 走 `MultiDatabaseSchemaTree`；已配置则锁定单库走 `StandardSchemaTree`。会话 `isMultiDatabase = hasMultiDatabase && 可见库数量 > 1`（库选择器等） |
+| `hasMultiDatabase` | 驱动**能力**标志。未配置逻辑库时走 `MultiDatabaseSchemaTree`；配置了逻辑库且该库 ∈ `get_databases` 时锁定 `StandardSchemaTree`。`databaseFieldType: 'domain'`（Kiwi）时 `connection.database` 为实例域名，**不**触发锁定 |
+| `databaseFieldType` | `name` / `path` / `index` / `domain`（Kiwi 实例域名） |
 | `defaultPageSize` | 覆盖默认分页（如 Kiwi 1000 行） |
 | `supportsBackup` | BackupWindow 过滤 + 方言备份选项 |
 

--- a/docs/progress-kiwi-database-permission-f1-test.md
+++ b/docs/progress-kiwi-database-permission-f1-test.md
@@ -1,0 +1,92 @@
+# F1 测试报告：`resolveVisibleDatabases` Kiwi domain 误锁修复
+
+**分支**：`fix/kiwi-database-permission-load`  
+**Commit**：`b07d243` — fix: harden plugin stash restore, window show, and workflow docs  
+**测试时间**：2026-08-07  
+**Agent 模式**：report-only（未改业务代码、未 commit）
+
+## 测试目标（F1）
+
+`resolveVisibleDatabases` 仅当 `preferredDatabase` 出现在 `get_databases` 返回列表中才锁定单库；否则列出全部库（修复 Kiwi 将 instance domain 误当成逻辑库并触发 `get_tables(domain)` 的问题）。
+
+---
+
+## 必跑：Vitest
+
+```bash
+cd /Users/flyxl/code/datazen
+npx vitest run src/stores/__tests__/schemaStore.test.ts
+```
+
+### 命令输出摘要
+
+```
+ RUN  v4.1.10 /Users/flyxl/code/datazen
+
+ Test Files  1 passed (1)
+      Tests  12 passed (12)
+   Duration  ~686–809ms
+
+✓ computeIsMultiDatabase / resolvePreferredDatabase / resolveVisibleDatabases > is multi only when capability and length > 1
+✓ schemaStore.loadForConnection isMultiDatabase > locks to configured database and disables multi-db session
+✓ schemaStore.loadForConnection isMultiDatabase > lists all databases when none configured (mysql)
+✓ schemaStore.loadForConnection isMultiDatabase > sets isMultiDatabase false for mysql with a single database
+✓ schemaStore.loadForConnection isMultiDatabase > sets isMultiDatabase true for postgresql with multiple databases
+✓ schemaStore.loadForConnection isMultiDatabase > falls back to listing all when preferred is empty string
+✓ schemaStore.loadForConnection isMultiDatabase > does not lock when configured database is absent from server list (e.g. Kiwi domain)
+✓ schemaStore.loadTables > does not call getColumns during loadTables
+✓ schemaStore.loadTables > calls useDatabase before getTables
+✓ schemaStore.loadTables > populates tables but leaves columnMap empty after loadTables
+✓ schemaStore.loadColumnMap > loads columns for all tables sequentially when called
+✓ schemaStore.loadColumnMap > does nothing when connectionId is null
+```
+
+**结果**：12/12 PASS，exit code 0。
+
+---
+
+## 静态核对：`resolveVisibleDatabases`
+
+**文件**：`src/stores/schemaStore.ts`（L33–49）
+
+| 场景 | 预期 | 实现 | 核对 |
+|------|------|------|------|
+| `preferredDatabase` trim 后非空且在 `allDatabases` 中 | 锁定单库：`databases=[configured]`，`lockedToConfigured=true` | L38–43：`configured && allDatabases.includes(configured)` → 返回单库 | **PASS** |
+| `preferredDatabase` 不在列表（如 Kiwi domain） | 不锁定：`databases=allDatabases`，`lockedToConfigured=false` | L45–49：走 else 分支，返回完整列表 | **PASS** |
+| 不在列表时 preferred 回退 | 回退到列表首项（经 `resolvePreferredDatabase`） | L47：`resolvePreferredDatabase(allDatabases, configured \|\| undefined)`；该 helper 在 preferred 不在列表时返回 `databases[0]`（L22） | **PASS** |
+| 空白 preferred | 视为未配置，列出全部 | L37：`preferredDatabase?.trim()` 为空则不进 lock 分支 | **PASS** |
+
+**集成路径**（`loadForConnection`，L101–112）：
+
+- `lockedToConfigured=false` 时 `isMultiDatabase` 由 `computeIsMultiDatabase(meta?.hasMultiDatabase, databases.length)` 决定（L105–107）。
+- 仅当 `preferred` 非空且未 `skipLoadTables` 时才调用 `loadTables(preferred)`（L110–112）；domain 不在列表时 `preferred` 为列表首项，不会对 domain 调 `get_tables`。
+
+**单元用例直接覆盖 F1**（`schemaStore.test.ts`）：
+
+- Kiwi-style：`resolveVisibleDatabases(['app_db','other'], 'afi-ph-useraccount-dbreader.aku')` → 全列表 + `preferred:'app_db'` + `lockedToConfigured:false` — **PASS**
+- 集成：`does not lock when configured database is absent from server list (e.g. Kiwi domain)` — **PASS**
+
+---
+
+## 用例表
+
+| ID | 类型 | 用例 | 结果 |
+|----|------|------|------|
+| F1-UT-01 | 单元 | 配置库在 `get_databases` 列表中 → lock 单库 | **PASS** |
+| F1-UT-02 | 单元 | 配置库不在列表（Kiwi domain 样例）→ 不 lock，preferred 为首项 | **PASS** |
+| F1-UT-03 | 单元 | preferred 为空/空白 → 不 lock，列出全部 | **PASS** |
+| F1-IT-01 | 集成 | `loadForConnection` + 配置库在列表 → `isMultiDatabase=false`，仅单库 | **PASS** |
+| F1-IT-02 | 集成 | `loadForConnection` + 配置库不在列表 → 全列表、`isMultiDatabase=true`、current 为首项 | **PASS** |
+| F1-BB-01 | 黑盒 | 连接 Kiwi → Connection Window 不对 domain 调 `get_tables`，能列出逻辑库 | **BLOCKED** |
+
+### 黑盒 BLOCKED 原因
+
+- DataZen 桌面应用当前未运行（`pgrep` 无 datazen/tauri 进程）。
+- `e2e/.env` 存在但未配置 `E2E_KIWI_*` 凭证（无 Kiwi URL/token/username/domain）。
+- 无法在 report-only 会话内启动带 Kiwi 插件的完整应用并完成手工验证。
+
+---
+
+## 结论
+
+**F1 在单元/集成层验证通过（12/12 Vitest PASS，静态逻辑与 F1 需求一致）；黑盒 Kiwi 场景 BLOCKED，待有凭证与运行中的应用后补测。**

--- a/docs/progress-kiwi-database-permission-f2-test.md
+++ b/docs/progress-kiwi-database-permission-f2-test.md
@@ -1,0 +1,139 @@
+# F2 测试报告：`databaseFieldType: 'domain'` + SchemaTree 多库路由
+
+**分支**：`fix/kiwi-database-permission-load`  
+**HEAD commit**：`50820b1` — fix(schema): only lock sidebar when configured DB is in list（F1）  
+**测试时间**：2026-08-07  
+**Agent 模式**：report-only（未改业务代码、未 commit）
+
+> **说明**：F2 相关改动存在于**工作区未提交 diff**（`SchemaTree.tsx`、`databaseMeta.ts`、测试、`plugins-registry.json` 等）。Vitest 与静态核对均针对当前工作区执行。
+
+## 测试目标（F2）
+
+1. `databaseFieldType: 'domain'` 元数据（类型定义 + Kiwi 插件 meta）
+2. `shouldUseMultiDatabaseTree`：`domain` 类型即使有 `initialDatabase` 也走多库树
+3. `SchemaTree`：`domain` 时 strip `initialDatabase` 再交给 `MultiDatabaseSchemaTree`
+4. Kiwi 插件 pin `b9cc1bdd2884ef9f95287c0b038664ec9f4f3598`
+
+---
+
+## 必跑：Vitest
+
+```bash
+cd /Users/flyxl/code/datazen
+npx vitest run \
+  src/windows/connection/schema-tree/__tests__/SchemaTree.test.tsx \
+  src/lib/__tests__/databaseTypes.test.ts \
+  src/stores/__tests__/schemaStore.test.ts
+```
+
+### 命令输出摘要
+
+```
+ RUN  v4.1.10 /Users/flyxl/code/datazen
+
+ Test Files  3 passed (3)
+      Tests  27 passed (27)
+   Duration  1.17–1.30s
+   Exit code: 0
+```
+
+### 与 F2 直接相关的用例
+
+| 文件 | 用例 | 结果 |
+|------|------|------|
+| `SchemaTree.test.tsx` | `shouldUseMultiDatabaseTree ignores domain field as logical lock` | ✅ PASS |
+| `SchemaTree.test.tsx` | mysql/pg 有/无 `initialDatabase` 路由（回归） | ✅ PASS（6 用例） |
+| `databaseTypes.test.ts` | `kiwi has multi-database and fixed page size when plugin is loaded` | ⚠️ 见下方 |
+| `schemaStore.test.ts` | `does not lock when configured database is absent from server list (e.g. Kiwi domain)` | ✅ PASS（F1 协同） |
+
+**`databaseTypes.test.ts` 备注**：`DB_REGISTRY.kiwi` 在本工作区未注入（`src/plugins/generated.ts` 中 `PLUGIN_DB_ENTRIES` 为空，`.plugins/` 不存在）。该用例通过 `if (!DB_REGISTRY.kiwi) return` 早退，**未实际断言** Kiwi meta。Kiwi `databaseFieldType: 'domain'` 改由远程 pin 静态核对覆盖（见下）。
+
+---
+
+## 静态核对
+
+### 1. `SchemaTree.tsx` — `shouldUseMultiDatabaseTree` + domain strip
+
+**文件**：`src/windows/connection/schema-tree/SchemaTree.tsx`
+
+| 检查项 | 预期 | 实际 | 结果 |
+|--------|------|------|------|
+| 导出 `shouldUseMultiDatabaseTree` | 存在 | L25–32 | ✅ |
+| `databaseFieldType === 'domain'` → 返回 `true`（忽略 `initialDatabase`） | `return true` | L30 | ✅ |
+| 非 domain：有 `initialDatabase` → `false` | `!initialDatabase?.trim()` | L31 | ✅ |
+| 路由 Multi 树前 strip domain | `{ ...props, initialDatabase: undefined }` | L54–57 | ✅ |
+| 注释说明 Kiwi domain 语义 | 有 | L18–24 | ✅ |
+
+核心逻辑：
+
+```typescript
+if (meta.databaseFieldType === 'domain') return true;
+// ...
+const treeProps =
+  meta?.databaseFieldType === 'domain'
+    ? { ...props, initialDatabase: undefined }
+    : props;
+```
+
+### 2. `databaseMeta.ts` — 类型扩展
+
+**文件**：`src/lib/databaseMeta.ts`
+
+| 检查项 | 结果 |
+|--------|------|
+| `databaseFieldType` 联合含 `'domain'` | ✅ |
+| 注释说明 domain = 实例 host/domain，不参与 sidebar lock | ✅ |
+
+### 3. Kiwi 插件 meta — `databaseFieldType: 'domain'`
+
+| 来源 | 结果 |
+|------|------|
+| 本地 `.plugins/kiwi/ui/plugin-meta.ts` | ❌ 不可用（`.plugins/` 未生成） |
+| 远程 `datazen-driver-kiwi` @ `b9cc1bd`（`git show …:ui/plugin-meta.ts`） | ✅ `databaseFieldType: 'domain'`，`hasMultiDatabase: true`，`defaultPageSize: 999` |
+
+### 4. `plugins-registry.json` — Kiwi ref pin
+
+**文件**：`plugins-registry.json`（工作区 diff，未 commit）
+
+| 检查项 | 预期 | 实际 | 结果 |
+|--------|------|------|------|
+| kiwi `ref` | `b9cc1bdd2884ef9f95287c0b038664ec9f4f3598` | L21 匹配 | ✅ |
+| 相对 HEAD commit | 已提交 | 仍为 `a17b12f…`（F2 pin 仅在工作区） | ⚠️ 未 commit |
+
+---
+
+## F2 行为矩阵（`shouldUseMultiDatabaseTree`）
+
+| hasMultiDatabase | databaseFieldType | initialDatabase | 期望 | 测试覆盖 |
+|------------------|-------------------|-----------------|------|----------|
+| true | domain | `afi-ph-useraccount-dbreader.aku` | Multi 树 | ✅ 单元测试 |
+| true | name | `datazen_test` | Standard 树 | ✅ 单元 + 集成 |
+| true | name | undefined | Multi 树 | ✅ 单元 + 集成 |
+| false | domain | any | Standard 树 | ✅ 单元测试 |
+
+---
+
+## 结论
+
+| 维度 | 结论 |
+|------|------|
+| Vitest（3 文件 / 27 用例） | **PASS**（exit 0） |
+| `SchemaTree` domain 路由逻辑 | **PASS** |
+| `databaseMeta` `'domain'` 类型 | **PASS** |
+| Kiwi 插件 meta @ `b9cc1bd` | **PASS**（远程核对） |
+| Registry pin `b9cc1bd` | **PASS**（工作区；HEAD 未含此 pin） |
+| 本地 plugin inject / `DB_REGISTRY.kiwi` 断言 | **SKIP**（无 `.plugins/`） |
+
+### 总评：**PASS**（附注）
+
+F2 核心实现与专用单元测试均通过；Kiwi 插件 meta 与 registry pin 在工作区 / 远程 ref 上核对一致。  
+**待办（非本 agent 范围）**：F2 diff 尚未 commit；合并前需 `resolve-plugins` 注入 kiwi 后复跑 `databaseTypes.test.ts` 以激活 Kiwi meta 断言。
+
+---
+
+## 相关文件
+
+- 实现：`src/windows/connection/schema-tree/SchemaTree.tsx`、`src/lib/databaseMeta.ts`
+- 测试：`src/windows/connection/schema-tree/__tests__/SchemaTree.test.tsx`、`src/lib/__tests__/databaseTypes.test.ts`
+- 插件：`plugins-registry.json` → kiwi ref `b9cc1bd`
+- 进度主文档：[progress-kiwi-database-permission.md](./progress-kiwi-database-permission.md)

--- a/docs/progress-kiwi-database-permission.md
+++ b/docs/progress-kiwi-database-permission.md
@@ -20,16 +20,22 @@ F6「配置了 database 则锁定单库」之后：
 
 | ID | 功能 | 状态 | 提交 |
 |----|------|------|------|
-| F1 | `resolveVisibleDatabases`：仅当配置库 ∈ `get_databases` 结果时才锁定 | 🧪 testing | — |
-| F2 | `databaseFieldType: 'domain'` + SchemaTree 不对 domain 做单库锁定路由；Kiwi meta | 🔲 | — |
+| F1 | `resolveVisibleDatabases`：仅当配置库 ∈ `get_databases` 结果时才锁定 | ✅ PASS | `50820b1` |
+| F2 | `databaseFieldType: 'domain'` + SchemaTree 不对 domain 做单库锁定路由；Kiwi meta | ✅ PASS | （本提交） |
 
 ## 测试记录
 
 | ID | 测试 agent | 报告 | 结论 |
 |----|------------|------|------|
-| F1 | — | — | — |
+| F1 | [F1 test](72d6c2ef-88c1-4a71-96ea-3f444391cd01) | [f1-test](./progress-kiwi-database-permission-f1-test.md) | **PASS**（Vitest 12/12；黑盒 BLOCKED） |
 | F2 | — | — | — |
 
 ## 变更日志
 
-（按提交追加）
+### F1 — `50820b1`
+- `resolveVisibleDatabases`：仅 `allDatabases.includes(configured)` 时锁定
+- 单元测试覆盖 Kiwi domain 样例
+
+### F2 —（进行中）
+- `databaseFieldType: 'domain'`；Kiwi meta + SchemaTree `shouldUseMultiDatabaseTree`
+- kiwi 插件 commit `b9cc1bd`；registry pin 更新

--- a/docs/progress-kiwi-database-permission.md
+++ b/docs/progress-kiwi-database-permission.md
@@ -21,14 +21,14 @@ F6「配置了 database 则锁定单库」之后：
 | ID | 功能 | 状态 | 提交 |
 |----|------|------|------|
 | F1 | `resolveVisibleDatabases`：仅当配置库 ∈ `get_databases` 结果时才锁定 | ✅ PASS | `50820b1` |
-| F2 | `databaseFieldType: 'domain'` + SchemaTree 不对 domain 做单库锁定路由；Kiwi meta | ✅ PASS | （本提交） |
+| F2 | `databaseFieldType: 'domain'` + SchemaTree 不对 domain 做单库锁定路由；Kiwi meta | ✅ PASS | `389d93a` |
 
 ## 测试记录
 
 | ID | 测试 agent | 报告 | 结论 |
 |----|------------|------|------|
 | F1 | [F1 test](72d6c2ef-88c1-4a71-96ea-3f444391cd01) | [f1-test](./progress-kiwi-database-permission-f1-test.md) | **PASS**（Vitest 12/12；黑盒 BLOCKED） |
-| F2 | — | — | — |
+| F2 | [F2 test](bf183664-8573-49f2-9eb2-3169722a50e3) | [f2-test](./progress-kiwi-database-permission-f2-test.md) | **PASS**（Vitest 27/27） |
 
 ## 变更日志
 
@@ -36,6 +36,7 @@ F6「配置了 database 则锁定单库」之后：
 - `resolveVisibleDatabases`：仅 `allDatabases.includes(configured)` 时锁定
 - 单元测试覆盖 Kiwi domain 样例
 
-### F2 —（进行中）
+### F2 — `389d93a`
 - `databaseFieldType: 'domain'`；Kiwi meta + SchemaTree `shouldUseMultiDatabaseTree`
-- kiwi 插件 commit `b9cc1bd`；registry pin 更新
+- domain 时 strip `initialDatabase` 再交给 Multi 树
+- kiwi 插件 commit `b9cc1bd`（已合入 kiwi `main`）；`plugins-registry.json` pin 更新

--- a/docs/progress-kiwi-database-permission.md
+++ b/docs/progress-kiwi-database-permission.md
@@ -1,0 +1,35 @@
+# 进度：修复 Kiwi「无权限 / 加载数据库失败」
+
+> 分支：`fix/kiwi-database-permission-load`  
+> 现象：连接成功、`get_databases` 返回 8 个库后，`get_tables` 报  
+> `The user does not have permission for the database afi-ph-useraccount-dbreader.aku`
+
+## 根因（已确认）
+
+Kiwi 连接配置里 `config.database` 表示的是 **实例 domain**（如 `afi-ph-useraccount-dbreader.aku`），不是逻辑库名。
+
+F6「配置了 database 则锁定单库」之后：
+
+1. `SchemaTree` 见 `initialDatabase=domain` → 走 `StandardSchemaTree`
+2. `resolveVisibleDatabases` 把可见库锁成 `[domain]`
+3. `get_tables(database=domain)` → API 200 但业务错误无权限
+
+日志证据：`domain` 与 `database` 查询参数同为 domain 字符串。
+
+## 功能拆分
+
+| ID | 功能 | 状态 | 提交 |
+|----|------|------|------|
+| F1 | `resolveVisibleDatabases`：仅当配置库 ∈ `get_databases` 结果时才锁定 | 🧪 testing | — |
+| F2 | `databaseFieldType: 'domain'` + SchemaTree 不对 domain 做单库锁定路由；Kiwi meta | 🔲 | — |
+
+## 测试记录
+
+| ID | 测试 agent | 报告 | 结论 |
+|----|------------|------|------|
+| F1 | — | — | — |
+| F2 | — | — | — |
+
+## 变更日志
+
+（按提交追加）

--- a/plugins-registry.json
+++ b/plugins-registry.json
@@ -18,7 +18,7 @@
   "kiwi": {
     "source": "git",
     "git": "https://github.com/flyxl/datazen-driver-kiwi.git",
-    "ref": "a17b12faed666845745d6e17fb07e08386ddb434",
+    "ref": "b9cc1bdd2884ef9f95287c0b038664ec9f4f3598",
     "feature": "plugin-kiwi",
     "description": "Kiwi cloud database proxy",
     "tauriPlugin": {

--- a/src/lib/__tests__/databaseTypes.test.ts
+++ b/src/lib/__tests__/databaseTypes.test.ts
@@ -5,7 +5,8 @@ describe('DB_REGISTRY behavioral flags', () => {
   it('kiwi has multi-database and fixed page size when plugin is loaded', () => {
     if (!DB_REGISTRY.kiwi) return; // plugins not injected in this workspace
     expect(DB_REGISTRY.kiwi.hasMultiDatabase).toBe(true);
-    expect(DB_REGISTRY.kiwi.defaultPageSize).toBe(1000);
+    expect(DB_REGISTRY.kiwi.databaseFieldType).toBe('domain');
+    expect(DB_REGISTRY.kiwi.defaultPageSize).toBe(999);
     expect(DB_REGISTRY.kiwi.connectionForm).toBe('kiwi');
   });
 

--- a/src/lib/databaseMeta.ts
+++ b/src/lib/databaseMeta.ts
@@ -42,8 +42,13 @@ export interface DatabaseTypeMeta {
   connectionView: 'sql' | 'keyvalue' | 'document';
   /** SQL dialect family for DDL/index queries; undefined for non-SQL types */
   sqlDialect?: string;
-  /** How the "database" field behaves in the connection form */
-  databaseFieldType: 'name' | 'path' | 'index';
+  /** How the "database" field behaves in the connection form.
+   *  - name: logical database name (MySQL/PG)
+   *  - path: file path (SQLite)
+   *  - index: numeric index (Redis)
+   *  - domain: instance host/domain for a proxy (Kiwi) — NOT a logical DB for sidebar lock
+   */
+  databaseFieldType: 'name' | 'path' | 'index' | 'domain';
   /** Driver capability: schema tree can browse multiple databases (MySQL/MariaDB/PostgreSQL/Kiwi). Session UI uses hasMultiDatabase && databases.length > 1. */
   hasMultiDatabase?: boolean;
   /** Default page size for table data; unset uses per-table or global default */

--- a/src/stores/__tests__/schemaStore.test.ts
+++ b/src/stores/__tests__/schemaStore.test.ts
@@ -43,6 +43,12 @@ describe('computeIsMultiDatabase / resolvePreferredDatabase / resolveVisibleData
       preferred: 'a',
       lockedToConfigured: false,
     });
+    // Kiwi-style: preferred is instance domain, not in logical DB list → do not lock
+    expect(resolveVisibleDatabases(['app_db', 'other'], 'afi-ph-useraccount-dbreader.aku')).toEqual({
+      databases: ['app_db', 'other'],
+      preferred: 'app_db',
+      lockedToConfigured: false,
+    });
   });
 });
 
@@ -129,7 +135,7 @@ describe('schemaStore.loadForConnection isMultiDatabase', () => {
     expect(useSchemaStore.getState().isMultiDatabase).toBe(true);
   });
 
-  it('locks even when configured database is absent from server list', async () => {
+  it('does not lock when configured database is absent from server list (e.g. Kiwi domain)', async () => {
     vi.mocked(databaseCommands.getDatabases).mockResolvedValueOnce(['alpha', 'beta']);
 
     await useSchemaStore.getState().loadForConnection('conn-1', {
@@ -138,9 +144,9 @@ describe('schemaStore.loadForConnection isMultiDatabase', () => {
       skipLoadTables: true,
     });
 
-    expect(useSchemaStore.getState().databases).toEqual(['nope']);
-    expect(useSchemaStore.getState().currentDatabase).toBe('nope');
-    expect(useSchemaStore.getState().isMultiDatabase).toBe(false);
+    expect(useSchemaStore.getState().databases).toEqual(['alpha', 'beta']);
+    expect(useSchemaStore.getState().currentDatabase).toBe('alpha');
+    expect(useSchemaStore.getState().isMultiDatabase).toBe(true);
   });
 });
 describe('schemaStore.loadTables', () => {

--- a/src/stores/schemaStore.ts
+++ b/src/stores/schemaStore.ts
@@ -23,15 +23,19 @@ export function resolvePreferredDatabase(
 }
 
 /**
- * When the connection config specifies a database, lock the sidebar to that
- * single database. Otherwise expose all databases returned by the driver.
+ * When the connection config specifies a *logical* database that appears in
+ * the driver list, lock the sidebar to that single database.
+ *
+ * If the preferred value is set but **not** in `allDatabases` (e.g. Kiwi stores
+ * the instance domain in `config.database`), do **not** lock — expose the full
+ * list and fall back to `resolvePreferredDatabase` semantics.
  */
 export function resolveVisibleDatabases(
   allDatabases: string[],
   preferredDatabase?: string,
 ): { databases: string[]; preferred: string | null; lockedToConfigured: boolean } {
   const configured = preferredDatabase?.trim();
-  if (configured) {
+  if (configured && allDatabases.includes(configured)) {
     return {
       databases: [configured],
       preferred: configured,
@@ -40,7 +44,7 @@ export function resolveVisibleDatabases(
   }
   return {
     databases: allDatabases,
-    preferred: allDatabases[0] ?? null,
+    preferred: resolvePreferredDatabase(allDatabases, configured || undefined),
     lockedToConfigured: false,
   };
 }

--- a/src/windows/connection/schema-tree/SchemaTree.tsx
+++ b/src/windows/connection/schema-tree/SchemaTree.tsx
@@ -1,4 +1,5 @@
 import { DB_REGISTRY } from '../../../lib/databaseTypes';
+import type { DatabaseTypeMeta } from '../../../lib/databaseMeta';
 import { getPluginSchemaTree } from '../../../plugins/generated';
 import type { DatabaseType } from '../../../types';
 import { MultiDatabaseSchemaTree } from './MultiDatabaseSchemaTree';
@@ -12,6 +13,22 @@ export interface SchemaTreeProps {
   searchQuery: string;
   onSelectTable: (table: string, schema?: string) => void;
   onTableContextMenu?: (tableName: string, x: number, y: number) => void;
+}
+
+/**
+ * Multi-DB tree when the driver supports it, unless connection.database is a
+ * *logical* DB name that should lock the sidebar.
+ *
+ * Kiwi (`databaseFieldType: 'domain'`) stores the instance domain in
+ * `connection.database` — that must not force StandardSchemaTree.
+ */
+export function shouldUseMultiDatabaseTree(
+  meta: Pick<DatabaseTypeMeta, 'hasMultiDatabase' | 'databaseFieldType'> | undefined,
+  initialDatabase?: string,
+): boolean {
+  if (!meta?.hasMultiDatabase) return false;
+  if (meta.databaseFieldType === 'domain') return true;
+  return !initialDatabase?.trim();
 }
 
 export function SchemaTree(props: SchemaTreeProps) {
@@ -32,10 +49,13 @@ export function SchemaTree(props: SchemaTreeProps) {
     }
   }
 
-  // Configured connection.database → single-DB tree only.
-  // Unconfigured → multi-DB tree when the driver supports it.
-  if (meta?.hasMultiDatabase && !props.initialDatabase?.trim()) {
-    return <MultiDatabaseSchemaTree {...props} />;
+  if (shouldUseMultiDatabaseTree(meta, props.initialDatabase)) {
+    // Domain is not a logical DB — don't pass it as preferredDatabase.
+    const treeProps =
+      meta?.databaseFieldType === 'domain'
+        ? { ...props, initialDatabase: undefined }
+        : props;
+    return <MultiDatabaseSchemaTree {...treeProps} />;
   }
   return <StandardSchemaTree {...props} isKeyValue={meta?.isKeyValue ?? false} />;
 }

--- a/src/windows/connection/schema-tree/__tests__/SchemaTree.test.tsx
+++ b/src/windows/connection/schema-tree/__tests__/SchemaTree.test.tsx
@@ -72,6 +72,34 @@ const baseProps = {
 };
 
 describe('SchemaTree routing', () => {
+  it('shouldUseMultiDatabaseTree ignores domain field as logical lock', async () => {
+    const { shouldUseMultiDatabaseTree } = await import('../SchemaTree');
+    expect(
+      shouldUseMultiDatabaseTree(
+        { hasMultiDatabase: true, databaseFieldType: 'domain' },
+        'afi-ph-useraccount-dbreader.aku',
+      ),
+    ).toBe(true);
+    expect(
+      shouldUseMultiDatabaseTree(
+        { hasMultiDatabase: true, databaseFieldType: 'name' },
+        'datazen_test',
+      ),
+    ).toBe(false);
+    expect(
+      shouldUseMultiDatabaseTree(
+        { hasMultiDatabase: true, databaseFieldType: 'name' },
+        undefined,
+      ),
+    ).toBe(true);
+    expect(
+      shouldUseMultiDatabaseTree(
+        { hasMultiDatabase: false, databaseFieldType: 'domain' },
+        'x',
+      ),
+    ).toBe(false);
+  });
+
   it('routes mysql with initialDatabase to StandardSchemaTree (single DB)', async () => {
     mockGetDatabases.mockResolvedValueOnce(['datazen_test', 'mysql', 'information_schema']);
 


### PR DESCRIPTION
## Summary
- Root cause: Kiwi `connection.database` is an **instance domain**, but F6 single-DB lock treated it as a logical DB → `get_tables(domain)` → permission error.
- **F1**: `resolveVisibleDatabases` only locks when the configured name is in `get_databases` results (`50820b1`).
- **F2**: Add `databaseFieldType: 'domain'`, SchemaTree always uses multi-DB tree for domain drivers, strip domain from preferred DB; pin kiwi plugin `b9cc1bd` (`389d93a`).

## Test plan
- [x] Vitest F1: `schemaStore.test.ts` 12/12 ([report](docs/progress-kiwi-database-permission-f1-test.md))
- [x] Vitest F2: SchemaTree + databaseTypes + schemaStore 27/27 ([report](docs/progress-kiwi-database-permission-f2-test.md))
- [ ] Manual: connect Kiwi → Connection Window lists logical DBs → expand DB loads tables (no domain in `get_tables` query)

## Progress
See [docs/progress-kiwi-database-permission.md](docs/progress-kiwi-database-permission.md).


Made with [Cursor](https://cursor.com)