### PR TITLE
docs: redesign README with bilingual product showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,10 @@ path = ../datazen-driver-mydb
 
 插件仓库和 Datazen 仓库保持独立。Datazen 的 registry 修改通过 Pull Request 提交，只有 PR 被合并后才会影响共享的 `main` 分支。
 
-完整的独立插件开发流程、Rust/前端集成方式和发布步骤请参阅 **[独立插件开发指南](docs/independent-plugin-development.md)**。
+**Documentation / 文档：**
+
+- [Independent Plugin Development — English](docs/independent-plugin-development.md)（默认）
+- [独立插件开发指南 — 中文](docs/independent-plugin-development.zh-CN.md)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -254,82 +254,116 @@ pnpm e2e
 
 ---
 
+## 独立插件开发
+
+Datazen Plugin 可以放在独立 Git 仓库中开发。插件源码不需要放入 Datazen 仓库，也不需要通过运行时加载 `.so` / `.dylib` / `.dll`。Rust 插件会在 **Datazen 编译期**被编译并链接进 Datazen，插件的前端代码也会作为 Datazen 前端构建的一部分参与集成。
+
+推荐使用两个同级 Git 仓库：
+
+```text
+~/workspace/
+├── datazen/
+└── datazen-driver-mydb/
+```
+
+### 开发步骤
+
+1. Clone Datazen 和独立 Plugin 仓库，并保持两个仓库同级。
+2. 在 `datazen/drivers-registry.json` 中增加或修改插件配置，开发阶段使用 `source: "path"`：
+
+```json
+{
+  "mydb": {
+    "source": "path",
+    "path": "../datazen-driver-mydb",
+    "feature": "plugin-mydb"
+  }
+}
+```
+
+3. 从 Datazen 仓库启动开发环境，并通过 `--drivers` 选择插件：
+
+```bash
+cd ~/workspace/datazen
+pnpm tauri:dev --drivers=mydb
+```
+
+4. 在 `datazen-driver-mydb` 中继续修改 Rust 和前端代码，然后重新运行/构建 Datazen 验证集成。
+
+### `--drivers` 的含义
+
+`--drivers` 是**编译期 Driver 选择**，不是运行时动态插件加载。大致流程如下：
+
+```text
+--drivers=mydb
+      │
+      ▼
+drivers-registry.json
+      │
+      ▼
+resolve-drivers.mjs
+      │
+      ├── Cargo dependency / feature
+      └── frontend plugin registry
+      │
+      ▼
+Datazen build
+      │
+      ▼
+Datazen binary
+```
+
+因此可以在真实 Datazen 应用中同时调试 Plugin 的 Rust 和前端代码，而不需要维护一个单独的 Mock Host。
+
+### 开发与发布
+
+开发阶段使用本地路径：
+
+```text
+source = path
+path = ../datazen-driver-mydb
+```
+
+插件完成后，可以将 Datazen registry 中的配置切换为独立 Git 仓库，并固定到一个 commit：
+
+```json
+{
+  "mydb": {
+    "source": "git",
+    "git": "https://github.com/example/datazen-driver-mydb.git",
+    "ref": "<commit-sha>",
+    "feature": "plugin-mydb"
+  }
+}
+```
+
+插件仓库和 Datazen 仓库保持独立。Datazen 的 registry 修改通过 Pull Request 提交，只有 PR 被合并后才会影响共享的 `main` 分支。
+
+完整的独立插件开发流程、Rust/前端集成方式和发布步骤请参阅 **[独立插件开发指南](docs/independent-plugin-development.md)**。
+
+---
+
 ## 添加新的数据库类型
 
 DataZen 支持两种方式添加新数据库驱动：
 
 ### 方式 1：作为外部插件（推荐）
 
-在独立仓库中开发，构建时按需组合。详见 **[插件开发指南](docs/plugin-development.md)**。
+在独立仓库中开发，构建时按需组合。详见 **[插件开发指南](docs/independent-plugin-development.md)**。
 
 ```bash
 # 构建时指定包含的驱动（path 与/或 git）
 DATAZEN_DRIVERS=kiwi,olap pnpm tauri build
 
-# 预设：all = 全部 path；basic = 四核心
-DATAZEN_DRIVERS=all pnpm tauri build
-DATAZEN_DRIVERS=basic pnpm tauri build
+# 预设：all = 全部 path... 
 ```
 
-### 方式 2：作为 path 原生驱动
+### 方式 2：内置 Driver
 
-在 `packages/drivers/<id>/` 实现并登记到 `drivers-registry.json`（`source: path`）。
-
-**后端**：
-1. 在 `packages/drivers/<id>/` 实现 `DatabaseDriver` trait 并用 `register_driver!` 注册
-2. 构建前由 `resolve-drivers.mjs` 注入 Cargo feature
-
-**前端**：
-1. 在 `src/lib/databaseTypes.ts` 的 `BUILTIN_DB_REGISTRY` 添加元数据
-2. 在 `src/types/index.ts` 的 `BuiltinDatabaseType` 添加类型
-
-### 验收清单
-
-- [ ] 无 `databaseType === 'xxx'` 硬编码（行为差异由 `DB_REGISTRY` 元数据驱动）
-- [ ] 视图/表单组件内部无方言 if-else（使用 `sqlDialects/` 策略）
-- [ ] `npx vitest run` + `cargo test` 通过
-
----
-
-## 项目结构
-
-```
-datazen/
-├── src/                         # React 前端
-│   ├── components/              # 通用 UI 组件
-│   ├── windows/                 # 各窗口页面（main, connection, settings 等）
-│   ├── stores/                  # Zustand 状态管理
-│   ├── commands/                # Tauri IPC 命令封装
-│   ├── lib/                     # DB_REGISTRY, sqlDialects, connectionViews
-│   ├── plugins/generated.ts     # 自动生成的驱动注册（resolve-drivers.mjs 产出）
-│   ├── locales/                 # 国际化（中/英）
-│   └── types/                   # TypeScript 类型定义
-├── src-tauri/                   # Rust 后端
-│   ├── src/
-│   │   ├── db/                  # 内置数据库驱动 + registry
-│   │   ├── commands/            # Tauri IPC（按领域拆分）
-│   │   └── store/               # 本地持久化
-│   └── Cargo.toml
-├── packages/driver-api/         # 插件公共 API crate（traits + types + inventory）
-├── scripts/resolve-drivers.mjs  # 驱动选型 + 代码生成
-├── drivers-registry.json        # 驱动注册表（path/git/local）
-├── .plugins/                    # 构建时克隆的插件目录（gitignored）
-├── e2e/                         # E2E 测试
-├── docs/                        # 文档
-│   ├── rfc-plugin-system.md     # 插件系统 RFC
-│   └── plugin-development.md    # 插件开发指南
-├── Cargo.toml                   # Workspace 根配置
-└── AGENTS.md                    # AI Agent 项目指引
-```
-
----
-
-## Marketing assets / 推广素材
-
-Screenshots, OG image, Product Hunt copy, and launch posts: [`docs/marketing/`](docs/marketing/).
+如果 Driver 需要随 DataZen 主仓库一起维护，可以放在 `packages/drivers/` 下，并在 registry 中注册。
 
 ---
 
 ## License
 
-[GPLv3](LICENSE)
+GPL-3.0

--- a/README.md
+++ b/README.md
@@ -1,372 +1,244 @@
-<p align="center">
-  <img src="public/logo.png" width="128" height="128" alt="DataZen Logo" />
-</p>
+<div align="center">
 
-<h1 align="center">DataZen</h1>
+<img src="site/assets/logo.png" width="96" alt="DataZen" />
 
-<p align="center">
-  <strong>轻量、快速、跨平台的桌面数据库管理工具</strong><br />
-  <strong>Lightweight, fast, cross-platform desktop database client</strong>
-</p>
+# DataZen
 
-<p align="center">
-  <a href="https://github.com/flyxl/datazen/releases"><img src="https://img.shields.io/github/v/release/flyxl/datazen?style=flat-square&color=00b4d8" alt="Release" /></a>
-  <img src="https://img.shields.io/badge/platforms-macOS%20%7C%20Windows%20%7C%20Linux-blue?style=flat-square" alt="Platforms" />
-  <img src="https://img.shields.io/badge/license-GPL--3.0-blue?style=flat-square" alt="License" />
-</p>
+### The lightweight, open-source AI database client for developers
 
-<p align="center">
-  <a href="https://github.com/flyxl/datazen/releases"><strong>Download</strong></a>
-  ·
-  <a href="https://flyxl.github.io/datazen/">Website</a>
-  ·
-  <a href="CONTRIBUTING.md">Contributing</a>
-  ·
-  <a href="mailto:wuxiaolongklws@gmail.com">Contact</a>
-</p>
+Natural-language SQL · Query analysis · Charts · Workflows · MCP · Extensible drivers
 
-<p align="center">
-  <img src="docs/screenshots/demo.gif" width="720" alt="DataZen demo" />
-</p>
+[![Release](https://img.shields.io/github/v/release/flyxl/datazen?style=flat-square)](https://github.com/flyxl/datazen/releases)
+[![License](https://img.shields.io/badge/license-GPLv3-blue?style=flat-square)](LICENSE)
+[![Platforms](https://img.shields.io/badge/platforms-macOS%20%7C%20Windows%20%7C%20Linux-blue?style=flat-square)](#installation)
 
-<p align="center">
-  <img src="docs/screenshots/connection-window.png" width="720" alt="DataZen data browser" />
-</p>
+[Download](https://github.com/flyxl/datazen/releases) · [Website](https://flyxl.github.io/datazen/) · [中文](README.zh-CN.md) · [Contributing](CONTRIBUTING.md)
 
-[English](#features) · [中文](#特性) · [Install](#install) · [macOS note](#macos-first-launch) · [Linux note](#linux-install) · [Contributing](#contributing) · [Contact](#contact--feedback)
+</div>
 
----
+![DataZen main window](site/assets/screenshots/01-main-window.png)
 
-## About
+## Why DataZen?
 
-**DataZen** is a free, [GPLv3-licensed](LICENSE) database GUI for developers. Built with **Tauri + Rust**, it ships **Basic** (PostgreSQL / MySQL / SQLite / Redis — small default) and **All** (extra native engines such as MongoDB, SQL Server, ClickHouse, DuckDB). Compile from source with only the drivers you need (`DATAZEN_DRIVERS=…`) — you never pay for bloat you will not use. Multi-window workflow, **SSH tunnels**, SQL editor, backups, and PG↔MySQL sync included. Credentials stay on your machine (AES-256-GCM).
+DataZen is a desktop database client built with **Tauri + Rust**. It combines the everyday database tools developers expect with AI-assisted querying, visual analysis, automation, and a compile-time driver architecture.
 
-**DataZen** 是一款免费开源（GPLv3）的桌面数据库客户端，基于 **Tauri + Rust**。发布提供 **Basic**（PostgreSQL / MySQL / SQLite / Redis，默认小包）与 **All**（额外原生引擎：MongoDB、SQL Server、ClickHouse、DuckDB 等）。源码构建可用 `DATAZEN_DRIVERS=…` **只编译需要的类型**，不为大而全买单。支持多窗口、**SSH 隧道**、SQL 编辑器、备份与 PG↔MySQL 同步；连接密码本地加密存储。
+- **Lightweight** — Tauri + Rust keeps the application small and responsive.
+- **AI-native** — generate SQL, diagnose errors, understand execution plans, and work with database context through chat.
+- **Visual** — turn query results into charts without exporting to another tool.
+- **Automatable** — compose SQL and AI operations into reusable YAML workflows across databases.
+- **Extensible** — database drivers are integrated at compile time through the DataZen Driver API.
+- **Local-first** — credentials and database access stay on your machine.
+- **Open source** — GPLv3, with an architecture designed for community drivers and contributions.
 
----
+## A database client built around real workflows
 
-<a id="features"></a>
-## Features
+### SQL and data exploration
 
-- **Pay only for what you use** — download **Basic** or **All**; or compile a custom driver set with `DATAZEN_DRIVERS`
-- **Multi-database** — Basic: PostgreSQL, MySQL / MariaDB, SQLite, Redis; All adds MongoDB, SQL Server, ClickHouse, DuckDB, and more native engines
-- **SSH tunneling** — Connect via bastion; pure Rust, no local `ssh` client required
-- **SQL editor** — Syntax highlighting, table/column autocomplete, multi-statement runs, EXPLAIN viz
-- **Data browser** — Virtual scrolling, inline edit, sort/filter, pagination
-- **Redis deep ops** — Key browser (all types + batch + Size + gated Flush); command console; Monitor (Info / Memory / Slowlog / Stream); Standalone / Cluster / Sentinel + mTLS; Pub/Sub; RedisJSON (module probe); DUMP/RESTORE import/export
-- **Import / export** — CSV, JSON, SQL, Markdown, XLSX
-- **Backup** — One-click SQL dump (schema-only, data-only, gzip)
-- **Cross-DB sync** — PG ↔ MySQL schema compare and data sync with resume
-- **AI + MCP** — Multi-provider AI chat; MCP Server (`datazen --mcp`) with permission tiers + connection allowlist; MCP Client for external tools
-- **YAML Workflows** — Cross-database automations (query / AI / condition / foreach), also exposed via MCP
-- **Charts** — Query-result charts with smart recommendations
-- **Bilingual UI** — 10 locales
-- **Appearance** — Light / dark / system mode; install local **theme packs** (ZIP) from Settings for custom colors, fonts, and icons
+Write and run SQL in a modern editor, inspect results, browse tables, and move between query results and visualizations without leaving DataZen.
 
-<a id="特性"></a>
-## 特性
+![Query results and charts](site/assets/screenshots/02-query-chart.png)
 
-- **按需选用，不为大而全买单** — 下载 **Basic** 或 **All**；源码可用 `DATAZEN_DRIVERS` 只编进需要的驱动
-- **多数据库支持** — Basic：PostgreSQL、MySQL / MariaDB、SQLite、Redis；All 另含 MongoDB、SQL Server、ClickHouse、DuckDB 等原生引擎
-- **SSH 隧道** — 通过跳板机安全连接远程数据库，纯 Rust 实现，无需本地安装 SSH 客户端
-- **智能 SQL 编辑器** — 语法高亮、自动补全（表名 + 列名）、多语句执行、执行计划可视化
-- **数据浏览与编辑** — 虚拟滚动表格、行内编辑、排序/筛选、分页导航
-- **Redis 深度运维** — Key 浏览（全类型 + 批量 + Size + 门控 Flush）；命令台；Monitor（Info / Memory / Slowlog / Stream）；Standalone / Cluster / Sentinel + mTLS；Pub/Sub；RedisJSON（模块探测）；DUMP/RESTORE 导入导出
-- **数据导入/导出** — CSV、JSON、SQL、Markdown、XLSX
-- **数据库备份** — 一键备份为 SQL 文件（Schema / Data / Gzip）
-- **数据同步** — PG ↔ MySQL 表结构对比与数据同步，支持断点续传
-- **AI + MCP** — 多 Provider AI；MCP Server（`datazen --mcp`，权限分档 + 连接白名单）；MCP Client 接入外部工具
-- **YAML Workflow** — 跨库自动化（query / AI / condition / foreach），并可通过 MCP 调用
-- **图表** — 查询结果智能推荐图表
-- **多语言** — 10 语系
-- **外观主题** — 浅色 / 深色 / 跟随系统；可在设置中安装本地**主题包**（ZIP），定制配色、字体与图标
+### AI-assisted database work
 
-<p align="center">
-  <img src="docs/screenshots/main-window.png" width="360" alt="主窗口" />
-  <img src="docs/screenshots/new-connection.png" width="360" alt="新建连接" />
-</p>
-<p align="center">
-  <img src="docs/screenshots/query-editor.png" width="360" alt="SQL 编辑器" />
-  <img src="docs/screenshots/redis-view.png" width="360" alt="Redis 视图" />
-</p>
+DataZen puts AI next to the database instead of making you copy schema and errors into another application.
 
----
+![AI natural-language SQL](site/assets/screenshots/03-ai-nl2sql.png)
 
-## 技术栈
+**Natural language → SQL**
 
-| 层 | 技术 | 说明 |
-|----|------|------|
-| **桌面框架** | [Tauri v2](https://v2.tauri.app/) | Rust 后端 + Web 前端，安装包 < 10 MB |
-| **前端** | React 18 + TypeScript + Vite | 组件化开发，HMR 热更新 |
-| **状态管理** | Zustand | 轻量级，无样板代码 |
-| **UI** | Tailwind CSS + Lucide Icons | 暗色主题，响应式布局 |
-| **代码编辑器** | CodeMirror 6 | SQL 语法高亮 + 自动补全 |
-| **虚拟化** | @tanstack/react-virtual | 十万行级数据流畅滚动 |
-| **后端语言** | Rust | 内存安全，高性能异步 I/O |
-| **数据库驱动** | `packages/drivers/*`（编译时选型） | Basic / All / 自定义列表，进程内原生驱动 |
-| **SSH** | russh | 纯 Rust SSH 客户端，无系统依赖 |
-| **加密** | AES-256-GCM | 本地加密存储连接密码 |
-| **E2E 测试** | WebdriverIO | 跨平台自动化测试 |
-| **CI/CD** | GitHub Actions | 自动构建 macOS / Windows / Linux 安装包 |
+Describe what you need and DataZen uses the current database schema as context to generate executable SQL. Generated SQL can be executed immediately or inserted into the editor for further editing.
 
----
+![AI error diagnosis](site/assets/screenshots/05-ai-diagnosis.png)
 
-<a id="install"></a>
-## Install / 安装
+**SQL error diagnosis**
 
-Download from [Releases](https://github.com/flyxl/datazen/releases) · 从 [Releases](https://github.com/flyxl/datazen/releases) 下载：
+When a query fails, AI can combine the database error and schema context to explain the problem and propose corrected SQL.
 
-| 平台 | 格式 |
-|------|------|
-| macOS (Apple Silicon) | `.dmg` (文件名含 `macos-arm64`) |
-| macOS (Intel) | `.dmg` (文件名含 `macos-x64`) |
-| Windows | `.exe` / `.msi` (文件名含 `windows-x64`) |
-| Linux (x86_64) | `.deb` / `.rpm` / `.AppImage` (文件名含 `linux-x64`) |
+![AI EXPLAIN analysis](site/assets/screenshots/06-ai-explain.png)
 
-GitHub Release 为上述平台同时发布：
+**EXPLAIN analysis**
 
-| 变体 | 文件名后缀 | 内容 |
-|------|------------|------|
-| **Basic** | （无） | PostgreSQL / MySQL / SQLite / Redis |
-| **All** | `-all` | 全部 **path 原生驱动**（不含 Kiwi / Superset / OLAP） |
-| **Akulaku** | `-akulaku` | Basic + MongoDB + Kiwi + Superset（特定部署） |
+Visualize execution plans and use AI to identify bottlenecks, scan strategies, and optimization opportunities.
 
-### Package managers / 包管理器
+![AI Chat](site/assets/screenshots/07-ai-chat.png)
 
-Homebrew (macOS Basic, tap template in `packaging/homebrew/datazen.rb`):
+**Database-aware AI Chat**
 
-```bash
-brew tap flyxl/datazen
-brew install --cask datazen
-# If macOS blocks launch: xattr -cr /Applications/DataZen.app
+The AI sidebar can work with the current connection's schema and turn SQL from the conversation into editor-ready code.
+
+Supported AI integrations include OpenAI, Anthropic, DeepSeek, and compatible custom endpoints.
+
+## Turn query results into charts
+
+You should not need to export data to Excel just to understand it. DataZen can infer useful chart configurations from query results and switch between table and chart views.
+
+![Chart types](site/assets/screenshots/10-chart-types.png)
+
+Supported visualizations include line, bar, pie, scatter, and area charts, with aggregation, grouping, and PNG/SVG export.
+
+![Chart export](site/assets/screenshots/11-chart-export.png)
+
+## Automate database work with Workflows
+
+DataZen Workflows describe reusable database operations in YAML. A workflow can combine queries, AI steps, conditions, and loops, with each step connected to the database it needs.
+
+![Workflow editor](site/assets/screenshots/04-workflow.png)
+
+For example, one workflow can query orders from PostgreSQL, fetch logistics from MySQL, and let AI summarize the combined result.
+
+![Cross-database workflow](site/assets/screenshots/12-workflow-crossdb.png)
+
+Workflows can be started from the UI, the AI sidebar, MCP, or generated with AI.
+
+![Workflow execution](site/assets/screenshots/13-workflow-run.png)
+
+## MCP: connect DataZen to the AI tool ecosystem
+
+DataZen works both as an **MCP Server** and an **MCP Client**.
+
+### MCP Server
+
+Expose database operations, schema inspection, EXPLAIN, and workflows to external AI agents. DataZen also provides a headless stdio mode for automation and agent integrations.
+
+### MCP Client
+
+Connect external MCP servers to DataZen AI Chat and bring additional tools and context into database conversations.
+
+This makes DataZen useful not only as a GUI, but also as a database tool inside larger AI-assisted development workflows.
+
+## Extensible database drivers
+
+DataZen separates the application from database-specific implementation through the **DataZen Driver API**.
+
+```text
+                         DataZen
+                            │
+              ┌─────────────┴─────────────┐
+              │       DataZen Core        │
+              │  UI · Query · AI · MCP   │
+              └─────────────┬─────────────┘
+                            │
+                    DataZen Driver API
+                            │
+          ┌─────────────────┼─────────────────┐
+          │                 │                 │
+       PostgreSQL         MySQL          External drivers
+                                           │
+                              ┌────────────┼────────────┐
+                              │            │            │
+                           MongoDB      ClickHouse    OLAP...
 ```
 
-WinGet (Windows Basic x64, manifest template in `packaging/winget/`):
+Drivers are **compiled into DataZen** rather than loaded through an unstable Rust dynamic-library ABI. This allows a driver to provide both Rust database functionality and frontend UI while still remaining in its own repository.
 
-```powershell
-winget install Flyxl.DataZen
+### Independent driver development
+
+A driver can be developed in an independent repository next to a local DataZen checkout:
+
+```text
+workspace/
+├── datazen/
+└── datazen-driver-mydb/
 ```
 
-Release checksums for packaging are appended to each GitHub release body (Basic assets only). See [docs/updater.md](docs/updater.md) for signed auto-update setup.
+During development, DataZen's driver registry can point to the local repository with `source: "path"`. The DataZen application is then built with the selected driver, giving plugin developers a real host for both backend and frontend debugging.
 
-<a id="macos-first-launch"></a>
-### macOS first launch / 首次打开
+See the complete guides:
 
-The app is **not Apple-notarized** (typical for free OSS). You may see “damaged” or “cannot verify” on first open.
+- **[Independent Plugin Development — English](docs/independent-plugin-development.md)**
+- **[独立插件开发指南 — 中文](docs/independent-plugin-development.zh-CN.md)**
+- **[DataZen Driver API](https://github.com/flyxl/datazen-driver-api)**
 
-应用**未经 Apple 公证**（开源项目常见情况），首次打开可能提示「已损坏」或「无法验证」。
+## Supported databases
 
-**Fix / 解决方法** — run after installing:
+DataZen ships with a small default set and can be built with additional drivers.
 
-```bash
-xattr -cr /Applications/DataZen.app
-```
+| Database | Default / optional | Notes |
+|---|---|---|
+| PostgreSQL | Default | SQL, schema browser, EXPLAIN, AI context |
+| MySQL / MariaDB | Default | SQL, schema browser, EXPLAIN |
+| SQLite | Default | Embedded database workflow |
+| Redis | Default | Key browser, command console, monitoring, Pub/Sub |
+| MongoDB | Optional | Native driver |
+| ClickHouse | Optional | Native driver |
+| DuckDB | Optional | Native driver |
+| SQL Server | Optional | Native driver |
+| Presto / Trino and other OLAP engines | Plugin | External driver architecture |
 
-Then open normally. Share this step in reviews if macOS blocks launch — it is expected, not corruption.
+The exact driver set is controlled at build time, so a distribution does not have to ship every database engine.
 
-<a id="linux-install"></a>
-### Linux install / Linux 安装
+## Installation
 
-Official builds are **x86_64** (`.deb` / `.rpm` / `.AppImage`). Prefer AppImage for a quick try:
+Download the latest release from **[GitHub Releases](https://github.com/flyxl/datazen/releases)**.
 
-官方提供 **x86_64** 安装包（`.deb` / `.rpm` / `.AppImage`）。快速试用推荐 AppImage：
+| Platform | Package |
+|---|---|
+| macOS Apple Silicon | `.dmg` |
+| macOS Intel | `.dmg` |
+| Windows | `.exe` / `.msi` |
+| Linux x86_64 | `.deb` / `.rpm` / `.AppImage` |
 
-```bash
-chmod +x DataZen-*-linux-x64.AppImage
-./DataZen-*-linux-x64.AppImage
-```
+DataZen is free and does not require an account.
 
-- Some distros need `libfuse2` for AppImage. / 部分发行版运行 AppImage 需安装 `libfuse2`
-- Runtime needs WebKitGTK (e.g. `libwebkit2gtk-4.1-0` / `webkit2gtk4.1`). / 运行时依赖 WebKitGTK
-- Debian/Ubuntu: `sudo apt install ./DataZen-*-linux-x64.deb`
-- Fedora/RHEL: `sudo rpm -i ./DataZen-*-linux-x64.rpm`
+## Build from source
 
----
+### Prerequisites
 
-<a id="contact--feedback"></a>
-## Contact & feedback / 联系与反馈
-
-| Channel | Link |
-|---------|------|
-| **Email** | [wuxiaolongklws@gmail.com](mailto:wuxiaolongklws@gmail.com) |
-| **Issues** | [github.com/flyxl/datazen/issues](https://github.com/flyxl/datazen/issues) |
-| **Releases** | [github.com/flyxl/datazen/releases](https://github.com/flyxl/datazen/releases) |
-| **Discussions** | [github.com/flyxl/datazen/discussions](https://github.com/flyxl/datazen/discussions) |
-| **Contributing** | [CONTRIBUTING.md](CONTRIBUTING.md) |
-| **Security** | [SECURITY.md](SECURITY.md) |
-| **Code of Conduct** | [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) |
-
-We typically respond to issues and email within a few business days. Bug reports welcome via the issue templates (version + OS required).
-
-Issue 与邮件反馈一般在几个工作日内回复；提交 Bug 请使用 Issue 模板并注明版本与系统。
-
----
-
-<a id="contributing"></a>
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, tests, and PR expectations.
-Please follow the [Code of Conduct](CODE_OF_CONDUCT.md). Security reports go to [SECURITY.md](SECURITY.md).
-
----
-
-## 开发
-
-### 前置条件
-
-- [Node.js](https://nodejs.org/) ≥ 20
-- [pnpm](https://pnpm.io/) ≥ 9
-- [Rust](https://rustup.rs/) ≥ 1.77
-- Tauri v2 系统依赖：[参考文档](https://v2.tauri.app/start/prerequisites/)
-
-### 启动开发模式
+- Node.js >= 20
+- pnpm >= 9
+- Rust >= 1.77
+- Tauri v2 system dependencies
 
 ```bash
 pnpm install
 pnpm tauri dev
 ```
 
-### 构建发行版
+Build only the drivers you need:
 
 ```bash
-# 默认 Basic 四核心（postgres/mysql/sqlite/redis）
+# Default driver set
 pnpm tauri:build
 
-# 全部 path 原生驱动（不含 kiwi/superset/olap）
+# All supported path drivers
 DATAZEN_DRIVERS=all pnpm tauri:build
 
-# 自定义：只编译需要的类型（不为大而全买单）
+# Custom driver set
 DATAZEN_DRIVERS=postgres,mongodb pnpm tauri:build
-DATAZEN_DRIVERS=postgres,mysql,sqlite,redis,mongodb,kiwi,superset pnpm tauri:build
 ```
 
-GitHub Release：**Basic** / **All**（path）/ **Akulaku**（CI 显式驱动列表，非脚本预设）。
+## Security and privacy
 
-### 运行 E2E 测试
+DataZen is designed around local database access:
 
-```bash
-# 先配置测试环境变量
-cp e2e/.env.example e2e/.env
-# 编辑 e2e/.env 填入数据库连接信息
+- Database credentials are stored locally.
+- AI requests are sent to the provider configured by the user.
+- Database data is not uploaded to a DataZen cloud service.
+- SSH connections can be established directly from the application.
 
-pnpm e2e
-```
+Always review the privacy and security policies of the AI provider and endpoint you configure.
 
----
+## Documentation
 
-## 独立插件开发
+- [Project website](https://flyxl.github.io/datazen/)
+- [Independent Plugin Development](docs/independent-plugin-development.md)
+- [Chinese Plugin Development Guide](docs/independent-plugin-development.zh-CN.md)
+- [Driver API](https://github.com/flyxl/datazen-driver-api)
+- [Workflow Guide](docs/workflow-guide.en.md)
+- [Contributing](CONTRIBUTING.md)
 
-Datazen Plugin 可以放在独立 Git 仓库中开发。插件源码不需要放入 Datazen 仓库，也不需要通过运行时加载 `.so` / `.dylib` / `.dll`。Rust 插件会在 **Datazen 编译期**被编译并链接进 Datazen，插件的前端代码也会作为 Datazen 前端构建的一部分参与集成。
+## Contributing
 
-推荐使用两个同级 Git 仓库：
+DataZen welcomes bug reports, feature requests, database drivers, documentation improvements, and code contributions.
 
-```text
-~/workspace/
-├── datazen/
-└── datazen-driver-mydb/
-```
-
-### 开发步骤
-
-1. Clone Datazen 和独立 Plugin 仓库，并保持两个仓库同级。
-2. 在 `datazen/drivers-registry.json` 中增加或修改插件配置，开发阶段使用 `source: "path"`：
-
-```json
-{
-  "mydb": {
-    "source": "path",
-    "path": "../datazen-driver-mydb",
-    "feature": "plugin-mydb"
-  }
-}
-```
-
-3. 从 Datazen 仓库启动开发环境，并通过 `--drivers` 选择插件：
-
-```bash
-cd ~/workspace/datazen
-pnpm tauri:dev --drivers=mydb
-```
-
-4. 在 `datazen-driver-mydb` 中继续修改 Rust 和前端代码，然后重新运行/构建 Datazen 验证集成。
-
-### `--drivers` 的含义
-
-`--drivers` 是**编译期 Driver 选择**，不是运行时动态插件加载。大致流程如下：
-
-```text
---drivers=mydb
-      │
-      ▼
-drivers-registry.json
-      │
-      ▼
-resolve-drivers.mjs
-      │
-      ├── Cargo dependency / feature
-      └── frontend plugin registry
-      │
-      ▼
-Datazen build
-      │
-      ▼
-Datazen binary
-```
-
-因此可以在真实 Datazen 应用中同时调试 Plugin 的 Rust 和前端代码，而不需要维护一个单独的 Mock Host。
-
-### 开发与发布
-
-开发阶段使用本地路径：
-
-```text
-source = path
-path = ../datazen-driver-mydb
-```
-
-插件完成后，可以将 Datazen registry 中的配置切换为独立 Git 仓库，并固定到一个 commit：
-
-```json
-{
-  "mydb": {
-    "source": "git",
-    "git": "https://github.com/example/datazen-driver-mydb.git",
-    "ref": "<commit-sha>",
-    "feature": "plugin-mydb"
-  }
-}
-```
-
-插件仓库和 Datazen 仓库保持独立。Datazen 的 registry 修改通过 Pull Request 提交，只有 PR 被合并后才会影响共享的 `main` 分支。
-
-**Documentation / 文档：**
-
-- [Independent Plugin Development — English](docs/independent-plugin-development.md)（默认）
-- [独立插件开发指南 — 中文](docs/independent-plugin-development.zh-CN.md)
-
----
-
-## 添加新的数据库类型
-
-DataZen 支持两种方式添加新数据库驱动：
-
-### 方式 1：作为外部插件（推荐）
-
-在独立仓库中开发，构建时按需组合。详见 **[插件开发指南](docs/independent-plugin-development.md)**。
-
-```bash
-# 构建时指定包含的驱动（path 与/或 git）
-DATAZEN_DRIVERS=kiwi,olap pnpm tauri build
-
-# 预设：all = 全部 path... 
-```
-
-### 方式 2：内置 Driver
-
-如果 Driver 需要随 DataZen 主仓库一起维护，可以放在 `packages/drivers/` 下，并在 registry 中注册。
-
----
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request. Driver work should generally be developed in an independent driver repository and integrated through the DataZen driver registry.
 
 ## License
 
-GPL-3.0
+DataZen is licensed under the **GNU General Public License v3.0**. See [LICENSE](LICENSE).
+
+<div align="center">
+
+**DataZen — let AI handle the database work, and turn data into insight.**
+
+</div>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,244 @@
+<div align="center">
+
+<img src="site/assets/logo.png" width="96" alt="DataZen" />
+
+# DataZen
+
+### 面向开发者的轻量级、开源 AI 数据库客户端
+
+自然语言 SQL · 查询分析 · 图表 · Workflow · MCP · 可扩展 Driver
+
+[![Release](https://img.shields.io/github/v/release/flyxl/datazen?style=flat-square)](https://github.com/flyxl/datazen/releases)
+[![License](https://img.shields.io/badge/license-GPLv3-blue?style=flat-square)](LICENSE)
+[![Platforms](https://img.shields.io/badge/platforms-macOS%20%7C%20Windows%20%7C%20Linux-blue?style=flat-square)](#安装)
+
+[下载](https://github.com/flyxl/datazen/releases) · [官网](https://flyxl.github.io/datazen/zh/) · [English](README.md) · [贡献指南](CONTRIBUTING.md)
+
+</div>
+
+![DataZen 主界面](site/assets/screenshots/01-main-window.png)
+
+## 为什么选择 DataZen？
+
+DataZen 是一款基于 **Tauri + Rust** 构建的桌面数据库客户端。在传统数据库管理能力之外，DataZen 将 AI 辅助查询、执行计划分析、数据可视化、Workflow 自动化和 MCP 集成融入日常数据库工作流。
+
+- **轻量** — Tauri + Rust 带来更小的安装包和更快的启动速度。
+- **AI 原生** — 自然语言生成 SQL、错误诊断、EXPLAIN 分析，以及带数据库上下文的 AI Chat。
+- **可视化** — 查询结果可以直接转换成图表，无需导出到 Excel。
+- **可自动化** — 使用 YAML Workflow 编排 SQL、AI、条件和循环，并支持跨数据库执行。
+- **可扩展** — 数据库 Driver 通过 DataZen Driver API 在编译期集成。
+- **本地优先** — 数据库连接和凭据保留在本机。
+- **开源** — GPLv3，支持社区 Driver 和代码贡献。
+
+## 围绕真实开发流程构建
+
+### SQL 与数据探索
+
+在现代 SQL 编辑器中编写和执行 SQL，浏览 Schema 和数据，并直接在查询结果与图表之间切换。
+
+![查询结果与图表](site/assets/screenshots/02-query-chart.png)
+
+### AI 辅助数据库开发
+
+DataZen 将 AI 放在数据库旁边，而不是让开发者不断复制 Schema 和错误信息到另一个应用中。
+
+![AI 自然语言生成 SQL](site/assets/screenshots/03-ai-nl2sql.png)
+
+**自然语言 → SQL**
+
+用自然语言描述需求，DataZen 自动将当前数据库 Schema 作为上下文生成 SQL。生成结果可以直接执行，也可以填充到编辑器继续修改。
+
+![AI SQL 错误诊断](site/assets/screenshots/05-ai-diagnosis.png)
+
+**SQL 错误诊断**
+
+SQL 执行失败后，AI 可以结合数据库错误和 Schema 分析原因，并给出修正后的 SQL。
+
+![AI EXPLAIN 分析](site/assets/screenshots/06-ai-explain.png)
+
+**EXPLAIN 分析**
+
+将执行计划可视化，并通过 AI 识别执行瓶颈、扫描方式和潜在优化方向。
+
+![AI Chat](site/assets/screenshots/07-ai-chat.png)
+
+**带数据库上下文的 AI Chat**
+
+AI Sidebar 可以自动获取当前连接的 Schema，上下文中的 SQL 也可以一键插入编辑器。
+
+支持 OpenAI、Anthropic、DeepSeek 以及兼容协议的自定义 Endpoint。
+
+## 查询结果直接变成图表
+
+不需要为了分析数据先导出到 Excel。DataZen 可以根据查询结果自动推荐合适的图表配置，并在表格和图表之间快速切换。
+
+![多种图表类型](site/assets/screenshots/10-chart-types.png)
+
+支持折线图、柱状图、饼图、散点图和面积图，并支持聚合、分组以及 PNG / SVG 导出。
+
+![图表导出](site/assets/screenshots/11-chart-export.png)
+
+## 使用 Workflow 自动化数据库工作
+
+DataZen Workflow 使用 YAML 描述可复用的数据库操作，可以组合 Query、AI、Condition 和 Foreach，并让不同步骤使用不同数据库连接。
+
+![Workflow 编辑器](site/assets/screenshots/04-workflow.png)
+
+例如，一个 Workflow 可以从 PostgreSQL 查询订单，再从 MySQL 获取物流信息，最后让 AI 对组合结果进行总结。
+
+![跨数据库 Workflow](site/assets/screenshots/12-workflow-crossdb.png)
+
+Workflow 可以从 UI、AI Sidebar、MCP 运行，也可以由 AI 根据需求生成。
+
+![Workflow 执行](site/assets/screenshots/13-workflow-run.png)
+
+## MCP：连接 AI 工具生态
+
+DataZen 同时支持 **MCP Server** 和 **MCP Client**。
+
+### MCP Server
+
+向外部 AI Agent 暴露数据库查询、Schema、EXPLAIN、Workflow 等能力，并支持 stdio headless 模式，方便自动化和 Agent 集成。
+
+### MCP Client
+
+将外部 MCP Server 接入 DataZen AI Chat，把文件系统、搜索以及第三方工具等能力带入数据库对话。
+
+因此 DataZen 不只是一个 GUI，也可以成为更大的 AI 开发工作流中的数据库工具。
+
+## 可扩展的数据库 Driver 架构
+
+DataZen 通过 **DataZen Driver API** 将应用核心与具体数据库实现解耦。
+
+```text
+                         DataZen
+                            │
+              ┌─────────────┴─────────────┐
+              │       DataZen Core        │
+              │  UI · Query · AI · MCP   │
+              └─────────────┬─────────────┘
+                            │
+                    DataZen Driver API
+                            │
+          ┌─────────────────┼─────────────────┐
+          │                 │                 │
+       PostgreSQL         MySQL          外部 Driver
+                                           │
+                              ┌────────────┼────────────┐
+                              │            │            │
+                           MongoDB      ClickHouse    OLAP...
+```
+
+Driver **不是通过不稳定的 Rust 动态库 ABI 在运行时加载**，而是在 DataZen 编译期被编译并链接进应用。因此 Driver 可以同时包含 Rust 数据库实现和前端页面，同时保持独立 Git 仓库。
+
+### 独立 Driver 开发
+
+开发 Driver 时，可以使用两个同级 Git 仓库：
+
+```text
+workspace/
+├── datazen/
+└── datazen-driver-mydb/
+```
+
+开发阶段 DataZen 的 Driver Registry 可以通过 `source: "path"` 指向本地 Driver 仓库。之后在 DataZen 中编译指定 Driver，即可使用真实 Host 同时调试 Driver 的 Rust 后端和前端页面。
+
+详细文档：
+
+- **[独立插件开发指南 — 中文](docs/independent-plugin-development.zh-CN.md)**
+- **[Independent Plugin Development — English](docs/independent-plugin-development.md)**
+- **[DataZen Driver API](https://github.com/flyxl/datazen-driver-api)**
+
+## 支持的数据库
+
+DataZen 默认提供精简的 Driver 集合，也可以在编译时加入更多 Driver。
+
+| 数据库 | 类型 | 说明 |
+|---|---|---|
+| PostgreSQL | 默认 | SQL、Schema、EXPLAIN、AI 上下文 |
+| MySQL / MariaDB | 默认 | SQL、Schema、EXPLAIN |
+| SQLite | 默认 | 嵌入式数据库工作流 |
+| Redis | 默认 | Key 浏览、命令台、Monitor、Pub/Sub |
+| MongoDB | 可选 | 原生 Driver |
+| ClickHouse | 可选 | 原生 Driver |
+| DuckDB | 可选 | 原生 Driver |
+| SQL Server | 可选 | 原生 Driver |
+| Presto / Trino 等 OLAP | Plugin | 外部 Driver 架构 |
+
+Driver 集合由编译期配置决定，因此发行版不需要携带所有数据库引擎。
+
+## 安装
+
+从 **[GitHub Releases](https://github.com/flyxl/datazen/releases)** 下载最新版本。
+
+| 平台 | 安装包 |
+|---|---|
+| macOS Apple Silicon | `.dmg` |
+| macOS Intel | `.dmg` |
+| Windows | `.exe` / `.msi` |
+| Linux x86_64 | `.deb` / `.rpm` / `.AppImage` |
+
+DataZen 免费使用，不需要注册账号。
+
+## 从源码构建
+
+### 前置条件
+
+- Node.js >= 20
+- pnpm >= 9
+- Rust >= 1.77
+- Tauri v2 系统依赖
+
+```bash
+pnpm install
+pnpm tauri dev
+```
+
+只构建需要的 Driver：
+
+```bash
+# 默认 Driver 集合
+pnpm tauri:build
+
+# 全部 path Driver
+DATAZEN_DRIVERS=all pnpm tauri:build
+
+# 自定义 Driver 集合
+DATAZEN_DRIVERS=postgres,mongodb pnpm tauri:build
+```
+
+## 安全与隐私
+
+DataZen 按照本地数据库访问场景设计：
+
+- 数据库凭据保存在本地。
+- AI 请求发送到用户配置的 AI Provider。
+- DataZen 不提供云端数据库代理服务，也不会将数据库数据上传到 DataZen 云端。
+- SSH 连接可以直接由应用建立。
+
+使用 AI 功能时，请同时遵守你所配置的 AI Provider / Endpoint 的隐私和安全策略。
+
+## 文档
+
+- [项目官网](https://flyxl.github.io/datazen/zh/)
+- [独立插件开发指南](docs/independent-plugin-development.zh-CN.md)
+- [English Plugin Development Guide](docs/independent-plugin-development.md)
+- [Driver API](https://github.com/flyxl/datazen-driver-api)
+- [Workflow 指南](docs/workflow-guide.en.md)
+- [贡献指南](CONTRIBUTING.md)
+
+## 参与贡献
+
+欢迎提交 Bug、功能建议、数据库 Driver、文档改进以及代码贡献。
+
+提交 Pull Request 前请阅读 [CONTRIBUTING.md](CONTRIBUTING.md)。Driver 通常应该在独立 Driver 仓库中开发，再通过 DataZen Driver Registry 集成。
+
+## License
+
+DataZen 使用 **GNU General Public License v3.0** 开源。详见 [LICENSE](LICENSE)。
+
+<div align="center">
+
+**DataZen — 让 AI 处理数据库工作，让数据真正产生洞察。**
+
+</div>

--- a/docs/independent-plugin-development.md
+++ b/docs/independent-plugin-development.md
@@ -1,0 +1,344 @@
+# Independent Plugin Development
+
+This guide describes how to develop a Datazen plugin in its own Git repository while using a local Datazen checkout as the build and debugging host.
+
+The important point is that Datazen plugins are **compiled into Datazen at build time**. A plugin is not loaded from a `.so`, `.dylib`, or `.dll` at runtime. The recommended development setup is therefore two sibling repositories:
+
+```text
+workspace/
+├── datazen/
+└── datazen-driver-mydb/
+```
+
+The plugin repository remains independent, while the local Datazen repository is used to compile the plugin together with the application and to debug the complete Rust + frontend integration.
+
+## 1. Prerequisites
+
+Install the normal Datazen development prerequisites and make sure the Datazen repository can build successfully before adding your plugin.
+
+You also need a checkout of your plugin repository next to the Datazen repository:
+
+```text
+~/workspace/
+├── datazen/
+└── datazen-driver-mydb/
+```
+
+The two repositories do not need to be merged into one Git repository and the plugin does not need to become a member of Datazen's Git repository.
+
+## 2. Create the plugin repository
+
+A driver plugin should be an independent Rust project. A typical layout is:
+
+```text
+datazen-driver-mydb/
+├── Cargo.toml
+├── Cargo.lock
+├── src/
+│   └── ...
+├── ui/
+│   └── ...
+└── README.md
+```
+
+The exact Rust and frontend structure depends on the capabilities provided by the plugin. A plugin may contain only a Rust driver, or it may also provide frontend components such as database metadata, connection forms, connection views, settings, schema trees, SQL dialects, and related UI integration.
+
+The plugin should depend on the public Datazen driver API rather than on Datazen application internals.
+
+## 3. Register the local plugin in Datazen
+
+During local development, add the plugin to Datazen's `drivers-registry.json` using a `path` source.
+
+For example:
+
+```json
+{
+  "mydb": {
+    "source": "path",
+    "path": "../datazen-driver-mydb",
+    "feature": "plugin-mydb",
+    "description": "MyDB driver"
+  }
+}
+```
+
+The path is relative to the Datazen repository.
+
+The registry already uses this same `source: "path"` form for built-in drivers. It also supports `source: "git"` for independently hosted plugins. See the existing entries in `drivers-registry.json` for examples.
+
+> **Development workflow:** modifying `drivers-registry.json` locally is expected. The local change is simply part of your Datazen development checkout. It does not modify the GitHub `main` branch unless you commit it and submit a pull request and that pull request is merged.
+
+### Optional local overrides
+
+Datazen also supports `.drivers-dev.json` as a gitignored local override for an existing registry entry. This is useful when you want to keep the committed `drivers-registry.json` unchanged. For example:
+
+```json
+{
+  "kiwi": {
+    "source": "path",
+    "path": "../datazen-driver-kiwi"
+  }
+}
+```
+
+For a new plugin, editing `drivers-registry.json` directly is the simplest way to make the development setup explicit and reproducible inside your local checkout.
+
+## 4. Build Datazen with the plugin
+
+Datazen's driver selection is controlled by `--drivers` (or `DATAZEN_DRIVERS`). The resolver reads `drivers-registry.json`, resolves the requested driver IDs, generates the required build configuration, and injects the selected plugin dependencies/features into the Datazen build.
+
+For your plugin:
+
+```bash
+cd ~/workspace/datazen
+pnpm tauri:dev --drivers=mydb
+```
+
+You can also combine your plugin with the built-in drivers:
+
+```bash
+pnpm tauri:dev --drivers=basic,mydb
+```
+
+`basic` expands to the four core drivers (`postgres`, `mysql`, `sqlite`, and `redis`). `all` expands to all `source: "path"` drivers in the registry. An explicit comma-separated list can be used for custom driver sets.
+
+For example:
+
+```bash
+pnpm tauri:dev --drivers=postgres,mysql,mydb
+```
+
+### What `--drivers` actually does
+
+`--drivers` is a **build-time driver selection**, not a runtime dynamic-loader option.
+
+Conceptually:
+
+```text
+--drivers=mydb
+        │
+        ▼
+drivers-registry.json
+        │
+        ▼
+resolve-drivers.mjs
+        │
+        ├── Cargo dependency
+        ├── Cargo feature
+        └── generated frontend registry
+        │
+        ▼
+Datazen build
+        │
+        ▼
+Datazen binary containing the plugin
+```
+
+The Rust plugin is therefore compiled and linked into the Datazen application. At runtime Datazen discovers the compiled driver through its normal driver registration mechanism; the plugin is not loaded through a platform-specific shared-library ABI.
+
+## 5. Develop the Rust side
+
+Make changes directly in the plugin repository:
+
+```bash
+cd ~/workspace/datazen-driver-mydb
+```
+
+Then rebuild/run Datazen from the Datazen repository:
+
+```bash
+cd ~/workspace/datazen
+pnpm tauri:dev --drivers=mydb
+```
+
+Because the registry uses a local `path` dependency, Cargo builds the current source from `../datazen-driver-mydb`. There is no need to copy plugin source into `packages/` and no need to commit the plugin source to the Datazen repository.
+
+The plugin's Rust implementation should use the Datazen driver API and register its driver using the registration mechanism provided by the API. This allows the compiled plugin to participate in Datazen's normal driver registry.
+
+## 6. Develop the frontend side
+
+A plugin may also contribute frontend code. The selected plugin's frontend integration is included by the Datazen frontend build together with the rest of the application.
+
+This means frontend development should also be performed with the local Datazen checkout as the host:
+
+```text
+plugin repository
+      │
+      ├── Rust implementation
+      │
+      └── frontend implementation
+               │
+               ▼
+        Datazen frontend build
+               │
+               ▼
+          Datazen application
+```
+
+This is important for debugging because plugin UI code runs in the real Datazen application context rather than in a separate mock host. You can therefore debug the plugin together with Datazen's actual React/Tauri environment.
+
+The current driver resolver generates `src/plugins/generated.ts` from the selected driver set. Frontend contributions are therefore part of the same build-time selection as the Rust driver.
+
+When adding frontend functionality, follow the structure and conventions used by existing external plugins in the registry, such as Kiwi, OLAP, and Superset.
+
+## 7. Iterative development loop
+
+The normal development loop is:
+
+```text
+1. Edit plugin source
+       ↓
+2. Start/restart Datazen with --drivers=mydb
+       ↓
+3. Datazen resolves the local path plugin
+       ↓
+4. Rust + frontend are compiled into Datazen
+       ↓
+5. Debug the plugin in the real Datazen application
+       ↓
+6. Repeat
+```
+
+For Rust changes, Cargo recompiles the affected plugin code. For frontend changes, the normal Datazen frontend development tooling can be used to debug the resulting UI.
+
+## 8. Test the plugin independently
+
+The plugin repository should keep its own tests and CI. At minimum, test the driver implementation independently of the Datazen application where practical.
+
+For example:
+
+```bash
+cd ~/workspace/datazen-driver-mydb
+cargo test
+```
+
+If the plugin has frontend code, run the frontend project's normal test/type-check/build commands as defined by that plugin repository.
+
+These tests verify the plugin itself. Running Datazen with `--drivers=mydb` verifies the integration between the plugin and the current Datazen source tree.
+
+## 9. Before publishing the plugin
+
+A plugin should be validated in both forms:
+
+### Local integration
+
+```bash
+cd ~/workspace/datazen
+pnpm tauri:dev --drivers=mydb
+```
+
+This verifies that the current plugin source can be compiled into and used by Datazen.
+
+### Independent plugin build/test
+
+```bash
+cd ~/workspace/datazen-driver-mydb
+cargo test
+```
+
+Run the plugin repository's frontend checks as well when applicable.
+
+## 10. Switching from local development to a Git dependency
+
+After the plugin is published, Datazen can consume it from its independent Git repository.
+
+During development:
+
+```json
+{
+  "mydb": {
+    "source": "path",
+    "path": "../datazen-driver-mydb",
+    "feature": "plugin-mydb"
+  }
+}
+```
+
+For a committed Datazen registry entry, the plugin can instead be pinned to a Git revision:
+
+```json
+{
+  "mydb": {
+    "source": "git",
+    "git": "https://github.com/example/datazen-driver-mydb.git",
+    "ref": "<commit-sha>",
+    "feature": "plugin-mydb"
+  }
+}
+```
+
+Pinning a commit makes the Datazen build reproducible and avoids silently changing the plugin version used by a Datazen build.
+
+The transition is therefore:
+
+```text
+local development
+source = path
+path = ../datazen-driver-mydb
+        │
+        ▼
+validate integration
+        │
+        ▼
+publish plugin repository
+        │
+        ▼
+Datazen registry PR
+        │
+        ▼
+source = git
+ref = <pinned commit>
+```
+
+## 11. Submitting the Datazen registry change
+
+The plugin repository and Datazen repository remain separate Git repositories.
+
+When the plugin is ready for inclusion in Datazen:
+
+1. Push the plugin repository and publish the required revision.
+2. Create a branch in the Datazen repository.
+3. Change the plugin's registry entry from the local `path` source to the plugin's Git repository and pinned revision.
+4. Run the Datazen build/tests with the plugin selected.
+5. Open a pull request against Datazen.
+6. The Datazen repository owners review and merge the registry change.
+
+A local `drivers-registry.json` change used during development does not affect GitHub `main` by itself. Only a merged pull request changes the shared registry.
+
+## 12. Recommended repository layout
+
+A complete independent-plugin development workspace should look like:
+
+```text
+~/workspace/
+├── datazen/
+│   ├── drivers-registry.json
+│   ├── scripts/
+│   ├── src/
+│   ├── src-tauri/
+│   └── ...
+│
+└── datazen-driver-mydb/
+    ├── Cargo.toml
+    ├── Cargo.lock
+    ├── src/
+    ├── ui/
+    └── ...
+```
+
+The two repositories are independent, but the local filesystem layout allows Datazen's existing `source: "path"` and `--drivers` mechanisms to compile the plugin into the application.
+
+## 13. Summary
+
+The recommended development model is:
+
+- Keep the plugin in its **own Git repository**.
+- Keep the plugin checkout **next to the Datazen checkout**.
+- During development, register the plugin in Datazen with `source: "path"`.
+- Run Datazen with `pnpm tauri:dev --drivers=<plugin-id>`.
+- Let Datazen compile the plugin into the application at build time.
+- Use the real Datazen application to debug both Rust integration and frontend UI.
+- Keep plugin tests and CI in the plugin repository.
+- When ready to publish, change the Datazen registry entry to a pinned `source: "git"` revision through a pull request.
+
+This model keeps plugin source code independent while preserving Datazen's compile-time integration model and avoids the ABI/versioning problems of runtime Rust dynamic-library loading.

--- a/docs/independent-plugin-development.zh-CN.md
+++ b/docs/independent-plugin-development.zh-CN.md
@@ -1,0 +1,344 @@
+# 独立插件开发指南
+
+本文介绍如何在独立 Git 仓库中开发 Datazen Plugin，并使用本地 Datazen 源码作为完整的编译、运行和调试宿主。
+
+最重要的一点是：**Datazen Plugin 在编译期被编译并链接进 Datazen**。插件不是通过运行时加载 `.so`、`.dylib` 或 `.dll` 的方式工作。因此，推荐使用两个同级 Git 仓库：
+
+```text
+workspace/
+├── datazen/
+└── datazen-driver-mydb/
+```
+
+插件仓库保持独立，Datazen 仓库负责将插件与应用一起编译，并提供真实的 Rust + 前端运行环境用于调试。
+
+## 1. 前置条件
+
+首先确保 Datazen 本身能够正常安装依赖并启动开发环境。
+
+然后将插件仓库 clone 到 Datazen 仓库的同级目录：
+
+```text
+~/workspace/
+├── datazen/
+└── datazen-driver-mydb/
+```
+
+两个仓库不需要合并成一个 Git 仓库，插件也不需要放进 Datazen 的 `packages/` 目录。
+
+## 2. 创建插件仓库
+
+Driver Plugin 应该是独立的 Rust 工程。典型结构如下：
+
+```text
+datazen-driver-mydb/
+├── Cargo.toml
+├── Cargo.lock
+├── src/
+│   └── ...
+├── ui/
+│   └── ...
+└── README.md
+```
+
+具体 Rust 和前端目录结构取决于插件提供的能力。插件可以只包含 Rust Driver，也可以同时提供数据库元数据、连接表单、连接视图、设置、Schema Tree、SQL Dialect 等前端能力。
+
+插件应该依赖公开的 Datazen Driver API，而不是直接依赖 Datazen 应用内部实现。
+
+## 3. 在 Datazen 中注册本地插件
+
+本地开发时，在 Datazen 的 `drivers-registry.json` 中增加插件，并将 `source` 设置为 `path`。
+
+例如：
+
+```json
+{
+  "mydb": {
+    "source": "path",
+    "path": "../datazen-driver-mydb",
+    "feature": "plugin-mydb",
+    "description": "MyDB driver"
+  }
+}
+```
+
+`path` 相对于 Datazen 仓库目录计算。
+
+当前 registry 本身已经使用 `source: "path"` 表示本地/内置 Driver，同时也支持 `source: "git"` 表示独立托管的插件。可以参考 `drivers-registry.json` 中现有的 Driver 配置。
+
+> **注意：开发阶段直接修改本地 `drivers-registry.json` 是正常的。** 这个修改只存在于你的本地 Datazen 工作区。只有你提交 commit、创建 Pull Request，并且 PR 被合并后，才会影响 GitHub 上共享的 `main` 分支。
+
+### 可选：本地 override
+
+Datazen 也支持 `.drivers-dev.json` 作为 gitignored 的本地 override，用于在不修改已提交的 `drivers-registry.json` 的情况下覆盖现有配置。例如：
+
+```json
+{
+  "kiwi": {
+    "source": "path",
+    "path": "../datazen-driver-kiwi"
+  }
+}
+```
+
+对于新开发的插件，直接修改本地 `drivers-registry.json` 是最直观的方式，可以清楚地表达当前 Datazen checkout 要使用哪个插件源码。
+
+## 4. 使用插件编译 Datazen
+
+Datazen 通过 `--drivers`（或 `DATAZEN_DRIVERS`）选择 Driver。解析器读取 `drivers-registry.json`，解析指定的 Driver ID，然后生成构建配置，将选中的插件 dependency、feature 和前端注册信息注入 Datazen 构建。
+
+运行你的插件：
+
+```bash
+cd ~/workspace/datazen
+pnpm tauri:dev --drivers=mydb
+```
+
+也可以和内置 Driver 一起使用：
+
+```bash
+pnpm tauri:dev --drivers=basic,mydb
+```
+
+`basic` 会展开为四个核心 Driver：`postgres`、`mysql`、`sqlite` 和 `redis`。`all` 会展开为 registry 中所有 `source: "path"` 的 Driver。也可以直接使用逗号分隔的 Driver 列表。
+
+例如：
+
+```bash
+pnpm tauri:dev --drivers=postgres,mysql,mydb
+```
+
+### `--drivers` 到底做什么？
+
+`--drivers` 是**编译期 Driver 选择机制**，不是运行时动态插件加载机制。
+
+大致流程：
+
+```text
+--drivers=mydb
+        │
+        ▼
+drivers-registry.json
+        │
+        ▼
+resolve-drivers.mjs
+        │
+        ├── Cargo dependency
+        ├── Cargo feature
+        └── generated frontend registry
+        │
+        ▼
+Datazen build
+        │
+        ▼
+包含插件的 Datazen binary
+```
+
+因此 Rust Plugin 会被编译并链接进 Datazen。运行时 Datazen 通过正常的 Driver 注册机制发现已经编译进 binary 的 Driver，而不是通过平台相关的动态库 ABI 加载插件。
+
+## 5. 开发 Rust 部分
+
+直接在独立插件仓库中修改代码：
+
+```bash
+cd ~/workspace/datazen-driver-mydb
+```
+
+然后从 Datazen 仓库重新启动/编译：
+
+```bash
+cd ~/workspace/datazen
+pnpm tauri:dev --drivers=mydb
+```
+
+由于 registry 使用本地 `path` dependency，Cargo 会直接编译 `../datazen-driver-mydb` 当前工作区中的源码。不需要把插件代码复制到 `packages/`，也不需要把插件源码提交到 Datazen 仓库。
+
+插件的 Rust 实现应该使用 Datazen Driver API，并通过 API 提供的注册机制注册 Driver，使编译后的插件能够参与 Datazen 的 Driver Registry。
+
+## 6. 开发前端部分
+
+插件也可以提供前端代码。选中的插件前端集成会随着 Datazen 前端一起构建。
+
+因此前端开发同样应该使用本地 Datazen 作为宿主：
+
+```text
+plugin repository
+      │
+      ├── Rust implementation
+      │
+      └── frontend implementation
+               │
+               ▼
+        Datazen frontend build
+               │
+               ▼
+          Datazen application
+```
+
+这样做的好处是 Plugin UI 在真实的 Datazen 应用环境中运行，而不是在单独的 Mock Host 中运行，因此可以直接调试真实的 React/Tauri 上下文。
+
+当前 Driver resolver 会根据选择的 Driver 生成 `src/plugins/generated.ts`。因此前端 Plugin 和 Rust Driver 一样，都属于同一个编译期 Driver selection。
+
+新增前端功能时，应参考 registry 中已有的外部 Plugin，例如 Kiwi、OLAP 和 Superset 的结构和约定。
+
+## 7. 日常开发循环
+
+推荐的开发循环：
+
+```text
+1. 修改 Plugin 源码
+       ↓
+2. 使用 --drivers=mydb 启动/重新启动 Datazen
+       ↓
+3. Datazen 解析本地 path plugin
+       ↓
+4. Rust + frontend 被编译进 Datazen
+       ↓
+5. 在真实 Datazen 应用中调试 Plugin
+       ↓
+6. 重复
+```
+
+Rust 修改后，Cargo 会重新编译受影响的 Plugin 代码。前端修改则使用 Datazen 当前前端开发工具链进行调试。
+
+## 8. 独立测试插件
+
+Plugin 仓库应该维护自己的测试和 CI。至少应该尽可能独立测试 Driver 实现。
+
+例如：
+
+```bash
+cd ~/workspace/datazen-driver-mydb
+cargo test
+```
+
+如果 Plugin 包含前端代码，则运行该 Plugin 自己定义的测试、类型检查和构建命令。
+
+这些测试验证 Plugin 本身；使用 `pnpm tauri:dev --drivers=mydb` 运行 Datazen，则用于验证 Plugin 与当前 Datazen 源码的集成。
+
+## 9. 发布前验证
+
+发布前建议验证两个层面。
+
+### Datazen 集成测试
+
+```bash
+cd ~/workspace/datazen
+pnpm tauri:dev --drivers=mydb
+```
+
+确认当前 Plugin 源码能够被编译进 Datazen，并在真实应用中正常运行。
+
+### Plugin 独立测试
+
+```bash
+cd ~/workspace/datazen-driver-mydb
+cargo test
+```
+
+如果包含前端，也运行 Plugin 自己的前端检查。
+
+## 10. 从本地 path 切换到 Git dependency
+
+插件发布后，Datazen 可以直接从独立 Git 仓库获取插件。
+
+开发阶段：
+
+```json
+{
+  "mydb": {
+    "source": "path",
+    "path": "../datazen-driver-mydb",
+    "feature": "plugin-mydb"
+  }
+}
+```
+
+正式提交到 Datazen registry 时，可以改成 Git source，并固定一个 commit：
+
+```json
+{
+  "mydb": {
+    "source": "git",
+    "git": "https://github.com/example/datazen-driver-mydb.git",
+    "ref": "<commit-sha>",
+    "feature": "plugin-mydb"
+  }
+}
+```
+
+固定 commit 可以保证 Datazen 构建可复现，避免插件仓库内容变化导致 Datazen 构建结果发生不可控变化。
+
+整个过程：
+
+```text
+本地开发
+source = path
+path = ../datazen-driver-mydb
+        │
+        ▼
+验证 Datazen 集成
+        │
+        ▼
+发布 Plugin 仓库
+        │
+        ▼
+提交 Datazen Registry PR
+        │
+        ▼
+source = git
+ref = <pinned commit>
+```
+
+## 11. 提交 Datazen Registry 修改
+
+Plugin 仓库和 Datazen 仓库保持独立。
+
+Plugin 准备发布时：
+
+1. Push Plugin 仓库，并发布需要使用的 revision。
+2. 在 Datazen 仓库创建开发分支。
+3. 将 registry 中本地 `path` 配置修改为 Plugin Git 仓库和固定 revision。
+4. 使用选中的 Plugin 运行 Datazen 构建和测试。
+5. 创建 Datazen Pull Request。
+6. Datazen 仓库 Owner review 并 merge。
+
+本地开发时修改 `drivers-registry.json` **不会自动影响 GitHub `main`**。只有 PR 被 merge 后，共享 registry 才会发生变化。
+
+## 12. 推荐的 workspace 结构
+
+完整的独立 Plugin 开发 workspace：
+
+```text
+~/workspace/
+├── datazen/
+│   ├── drivers-registry.json
+│   ├── scripts/
+│   ├── src/
+│   ├── src-tauri/
+│   └── ...
+│
+└── datazen-driver-mydb/
+    ├── Cargo.toml
+    ├── Cargo.lock
+    ├── src/
+    ├── ui/
+    └── ...
+```
+
+两个仓库在 Git 层面完全独立，但通过同级目录关系，Datazen 可以使用现有的 `source: "path"` 和 `--drivers` 机制把 Plugin 编译进应用。
+
+## 13. 总结
+
+推荐的独立 Plugin 开发模式：
+
+- Plugin 保持在**独立 Git 仓库**。
+- Plugin checkout 与 Datazen checkout **放在同级目录**。
+- 开发阶段在 Datazen 的 `drivers-registry.json` 中使用 `source: "path"`。
+- 使用 `pnpm tauri:dev --drivers=<plugin-id>` 启动 Datazen。
+- 由 Datazen 在**编译期**把 Plugin 编译进应用。
+- 使用真实 Datazen 应用同时调试 Rust 集成和前端 UI。
+- Plugin 自己维护测试和 CI。
+- 发布时将 Datazen registry 切换为固定 commit 的 `source: "git"`，通过 Pull Request 提交。
+
+这种模式既保持了 Plugin 源码的独立性，又保留了 Datazen 的编译期集成模型，避免 Rust runtime dynamic-library loading 带来的 ABI 和版本兼容问题。


### PR DESCRIPTION
## Summary
- replace the existing README with a product-focused English README
- add `README.zh-CN.md` as the Chinese version
- use the existing `site/assets` screenshots to showcase SQL, AI, charts, workflows, and MCP
- document the compile-time Driver architecture and independent plugin development flow
- keep detailed plugin/API documentation in the dedicated docs and Driver API repository

## Validation
- Reviewed the README structure and referenced `site` assets
- Documentation-only change; no runtime code changes