### PR TITLE
build: publish driver API as MIT-licensed crate

### DIFF
--- a/.github/workflows/publish-driver-api.yml
+++ b/.github/workflows/publish-driver-api.yml
@@ -4,15 +4,15 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - 'driver-api-v*'
+      - 'datazen-driver-api-v*'
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   publish:
+    name: Publish datazen-driver-api
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -20,15 +20,16 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Cache Rust
-        uses: swatinem/rust-cache@v2
-        with:
-          workspaces: . -> target
+      - name: Check crate
+        run: cargo check -p datazen-driver-api
 
-      - name: Verify package
-        run: cargo package -p datazen-driver-api --allow-dirty
+      - name: Test crate
+        run: cargo test -p datazen-driver-api
 
-      - name: Publish datazen-driver-api
+      - name: Package crate
+        run: cargo package -p datazen-driver-api
+
+      - name: Publish crate
+        run: cargo publish -p datazen-driver-api --locked
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish -p datazen-driver-api

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,6 @@ lto = true
 codegen-units = 1
 opt-level = "s"
 
-[patch."https://github.com/flyxl/datazen-driver-api.git"]
-datazen-driver-api = { path = "packages/driver-api" }
-
 # Plugin patches — injected by resolve-drivers.mjs at build time; do NOT add manually.
 # <<plugin-patches>>
 # <</plugin-patches>>

--- a/README.md
+++ b/README.md
@@ -143,11 +143,15 @@ workspace/
 
 During development, DataZen's driver registry can point to the local repository with `source: "path"`. The DataZen application is then built with the selected driver, giving plugin developers a real host for both backend and frontend debugging.
 
+The Driver API itself is maintained in `packages/driver-api` and published as the MIT-licensed `datazen-driver-api` crate. Independent drivers normally consume the published crate and do not need to clone DataZen just to obtain the API.
+
 See the complete guides:
 
 - **[Independent Plugin Development — English](docs/independent-plugin-development.md)**
 - **[独立插件开发指南 — 中文](docs/independent-plugin-development.zh-CN.md)**
-- **[DataZen Driver API](https://github.com/flyxl/datazen-driver-api)**
+- **[Driver API crate README](packages/driver-api/README.md)**
+- **[Driver API dependency boundary](docs/driver-api/public-api-dependency-boundary.md)**
+- **[datazen-driver-api on crates.io](https://crates.io/crates/datazen-driver-api)**
 
 ## Supported databases
 
@@ -223,7 +227,9 @@ Always review the privacy and security policies of the AI provider and endpoint 
 - [Project website](https://flyxl.github.io/datazen/)
 - [Independent Plugin Development](docs/independent-plugin-development.md)
 - [Chinese Plugin Development Guide](docs/independent-plugin-development.zh-CN.md)
-- [Driver API](https://github.com/flyxl/datazen-driver-api)
+- [Driver API crate](packages/driver-api/README.md)
+- [Driver API dependency boundary](docs/driver-api/public-api-dependency-boundary.md)
+- [datazen-driver-api on crates.io](https://crates.io/crates/datazen-driver-api)
 - [Workflow Guide](docs/workflow-guide.en.md)
 - [Contributing](CONTRIBUTING.md)
 
@@ -235,7 +241,7 @@ Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request. Dr
 
 ## License
 
-DataZen is licensed under the **GNU General Public License v3.0**. See [LICENSE](LICENSE).
+DataZen is licensed under the **GNU General Public License v3.0**. The `datazen-driver-api` crate under `packages/driver-api` is separately licensed under the **MIT License**. See [LICENSE](LICENSE) and [packages/driver-api/LICENSE-MIT](packages/driver-api/LICENSE-MIT).
 
 <div align="center">
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -143,11 +143,15 @@ workspace/
 
 开发阶段 DataZen 的 Driver Registry 可以通过 `source: "path"` 指向本地 Driver 仓库。之后在 DataZen 中编译指定 Driver，即可使用真实 Host 同时调试 Driver 的 Rust 后端和前端页面。
 
+Driver API 本身维护在 DataZen monorepo 的 `packages/driver-api` 中，并作为 MIT License 的 `datazen-driver-api` crate 发布。独立 Driver 通常直接依赖 crates.io 上的 API，不需要为了获得 API 而 clone DataZen。
+
 详细文档：
 
 - **[独立插件开发指南 — 中文](docs/independent-plugin-development.zh-CN.md)**
 - **[Independent Plugin Development — English](docs/independent-plugin-development.md)**
-- **[DataZen Driver API](https://github.com/flyxl/datazen-driver-api)**
+- **[Driver API crate README](packages/driver-api/README.md)**
+- **[Driver API 依赖边界](docs/driver-api/public-api-dependency-boundary.md)**
+- **[datazen-driver-api on crates.io](https://crates.io/crates/datazen-driver-api)**
 
 ## 支持的数据库
 
@@ -223,7 +227,9 @@ DataZen 按照本地数据库访问场景设计：
 - [项目官网](https://flyxl.github.io/datazen/zh/)
 - [独立插件开发指南](docs/independent-plugin-development.zh-CN.md)
 - [English Plugin Development Guide](docs/independent-plugin-development.md)
-- [Driver API](https://github.com/flyxl/datazen-driver-api)
+- [Driver API crate](packages/driver-api/README.md)
+- [Driver API 依赖边界](docs/driver-api/public-api-dependency-boundary.md)
+- [datazen-driver-api on crates.io](https://crates.io/crates/datazen-driver-api)
 - [Workflow 指南](docs/workflow-guide.en.md)
 - [贡献指南](CONTRIBUTING.md)
 
@@ -235,7 +241,7 @@ DataZen 按照本地数据库访问场景设计：
 
 ## License
 
-DataZen 使用 **GNU General Public License v3.0** 开源。详见 [LICENSE](LICENSE)。
+DataZen 使用 **GNU General Public License v3.0** 开源。`packages/driver-api` 下的 `datazen-driver-api` crate 单独采用 **MIT License**。详见 [LICENSE](LICENSE) 和 [packages/driver-api/LICENSE-MIT](packages/driver-api/LICENSE-MIT)。
 
 <div align="center">
 

--- a/docs/driver-api/public-api-dependency-boundary.md
+++ b/docs/driver-api/public-api-dependency-boundary.md
@@ -1,0 +1,115 @@
+# Driver API Public Dependency Boundary
+
+`packages/driver-api` is the stable compile-time contract between DataZen and independent database driver plugins.
+
+The API is published as the MIT-licensed `datazen-driver-api` crate. Its source of truth is the DataZen monorepo; there is no separate Driver API source repository.
+
+## Public API rule
+
+Public Driver API signatures and public fields may use:
+
+- Rust primitives and standard-library types;
+- types defined by `datazen-driver-api` itself;
+- `serde` traits/attributes where required;
+- `serde_json::Value` and other transport-neutral JSON data types.
+
+They must not expose database implementation types.
+
+## Forbidden public dependencies
+
+The following must not appear in public traits, function signatures, public struct fields, enum variants, or public type aliases:
+
+- `sqlx` types such as `Pool`, `Row`, `Transaction`, or database-specific errors;
+- `tokio` runtime or synchronization types;
+- database-specific crates such as `mongodb`, `redis`, `clickhouse`, `mysql_async`, `tokio-postgres`, and similar libraries;
+- HTTP client implementation types such as `reqwest`;
+- database pools, rows, transactions, cursors, or implementation-specific error types;
+- any other third-party implementation type that an independent driver may reasonably need at a different version.
+
+For example, this is forbidden:
+
+```rust
+pub trait DatabaseDriver {
+    fn pool(&self) -> sqlx::Pool<sqlx::Postgres>;
+}
+```
+
+Instead, the Driver API should expose an opaque handle:
+
+```rust
+pub struct ConnectionHandle {
+    pub id: String,
+    pub pool_id: String,
+}
+```
+
+The driver owns and manages the real connection pool internally.
+
+## Dependency layering
+
+The intended dependency graph is:
+
+```text
+                         DataZen Host
+                              │
+                    datazen-driver-api
+                              │
+              ┌───────────────┼───────────────┐
+              │               │               │
+          Driver A         Driver B        Driver C
+              │               │               │
+           sqlx 0.7         sqlx 0.8        mongodb
+              │               │               │
+           private          private         private
+```
+
+Different drivers may use different database libraries or different versions of the same library. This is safe because implementation types never cross the API boundary.
+
+## Foundation dependencies
+
+`serde` and `serde_json` are allowed as transport-neutral data dependencies.
+
+`async-trait` is currently used to express asynchronous driver traits. It is part of the Rust API implementation surface, but it is not a database implementation dependency.
+
+`inventory` is intentionally used for compile-time driver registration. DataZen embeds drivers into the application binary rather than loading Rust shared libraries at runtime.
+
+## Versioning
+
+The Cargo crate version and the DataZen Driver protocol version are separate:
+
+- **Crate version** follows Cargo/SemVer compatibility rules for the Rust API.
+- **`PROTOCOL_VERSION`** represents DataZen ↔ Driver API protocol compatibility.
+
+Internal dependency changes that do not affect public API types do not require a protocol-version change. Breaking public trait or protocol changes must be evaluated for both versions.
+
+## Review checklist
+
+Before merging a change to `packages/driver-api`:
+
+- [ ] No `sqlx` type appears in public API.
+- [ ] No database-specific crate type appears in public API.
+- [ ] No `tokio` type appears in public API.
+- [ ] Connection pools remain owned by the driver.
+- [ ] Rows, cursors, and transactions use API-defined types or opaque handles.
+- [ ] Cross-boundary errors use `DriverError` or another API-defined error type.
+- [ ] Generic JSON data uses `serde_json` rather than a database-specific document type.
+- [ ] New third-party dependencies are checked for accidental public exposure.
+- [ ] Crate-version and protocol-version implications are considered.
+
+## Development and publishing
+
+DataZen itself consumes the crate through the workspace path dependency:
+
+```toml
+[workspace.dependencies]
+datazen-driver-api = { path = "packages/driver-api" }
+```
+
+Independent plugins normally consume the published crate:
+
+```toml
+[dependencies]
+datazen-driver-api = "0.1"
+```
+
+When developing an API change before publication, an independent plugin can temporarily use a local path dependency pointing at `packages/driver-api`.

--- a/packages/driver-api/Cargo.toml
+++ b/packages/driver-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datazen-driver-api"
-version = "0.1.0"
+version = "0.0.8"
 edition = "2021"
 description = "Public API (traits and types) for DataZen database driver plugins"
 license-file = "LICENSE-MIT"

--- a/packages/driver-api/Cargo.toml
+++ b/packages/driver-api/Cargo.toml
@@ -1,9 +1,15 @@
 [package]
 name = "datazen-driver-api"
-version = "0.0.8"
+version = "0.1.0"
 edition = "2021"
 description = "Public API (traits and types) for DataZen database driver plugins"
-license = "GPL-3.0-or-later"
+license-file = "LICENSE-MIT"
+repository = "https://github.com/flyxl/datazen"
+homepage = "https://flyxl.github.io/datazen/"
+documentation = "https://docs.rs/datazen-driver-api"
+readme = "README.md"
+keywords = ["datazen", "database", "driver", "plugin"]
+categories = ["database", "api-bindings"]
 
 [dependencies]
 async-trait = "0.1"

--- a/packages/driver-api/LICENSE-MIT
+++ b/packages/driver-api/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 DataZen contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/driver-api/README.md
+++ b/packages/driver-api/README.md
@@ -1,0 +1,79 @@
+# datazen-driver-api
+
+The stable Rust API used by [DataZen](https://github.com/flyxl/datazen) database driver plugins.
+
+The crate is maintained in the DataZen monorepo under `packages/driver-api` and is published independently to [crates.io](https://crates.io/). There is intentionally no separate source repository for the API crate.
+
+## License
+
+`datazen-driver-api` is licensed under the **MIT License**. The DataZen application itself is licensed separately under GPLv3.
+
+## Usage
+
+A third-party driver normally depends on the published crate:
+
+```toml
+[dependencies]
+datazen-driver-api = "0.1"
+```
+
+Then implement the public driver traits:
+
+```rust
+use datazen_driver_api::{DatabaseDriver, DriverError};
+
+// Implement DatabaseDriver for your driver type.
+```
+
+For local integration development, a driver can instead use a path dependency to a local DataZen checkout:
+
+```toml
+[dependencies]
+datazen-driver-api = { path = "../datazen/packages/driver-api" }
+```
+
+This is useful when developing a new API version before it is published.
+
+## API boundary
+
+The Driver API is deliberately independent of database implementation libraries. A driver may use `sqlx`, `tokio-postgres`, `mongodb`, `redis`, or another client internally, including a different version from another driver.
+
+Those implementation types must not appear in the public Driver API. Connection pools, rows, transactions, cursors, and database-specific errors remain private to the driver implementation. DataZen communicates through API-defined types such as `ConnectionHandle`, `QueryResult`, `Value`, and `DriverError`.
+
+See [`docs/public-api-dependency-boundary.md`](../../docs/public-api-dependency-boundary.md) for the complete dependency-boundary policy.
+
+## Versioning
+
+The Cargo crate version and the Driver protocol version are separate concepts:
+
+- **Crate version** follows Cargo/SemVer compatibility rules and controls Rust source compatibility.
+- **`PROTOCOL_VERSION`** describes compatibility of the DataZen Driver API protocol and is used by the host/driver integration layer.
+
+A breaking public API change should be evaluated for both versions. Internal dependency changes that do not affect public API types do not require a protocol-version change.
+
+## Development in the DataZen workspace
+
+The crate is a workspace member, so DataZen itself uses it through a local path dependency. Changes to `packages/driver-api` are therefore immediately available to the DataZen application and local driver integration builds.
+
+Useful commands from the repository root:
+
+```bash
+cargo check -p datazen-driver-api
+cargo test -p datazen-driver-api
+cargo doc -p datazen-driver-api --no-deps
+cargo package -p datazen-driver-api
+cargo publish --dry-run -p datazen-driver-api
+```
+
+Publishing is intentionally a release operation; normal development should use the workspace path dependency.
+
+## Independent driver development
+
+A driver developer does not need to clone DataZen merely to obtain the API. The normal flow is:
+
+1. Depend on `datazen-driver-api` from crates.io.
+2. Develop and test the driver independently.
+3. When full host/UI integration is needed, place the driver and a DataZen checkout in a local integration workspace and use the local Driver Registry path source.
+4. For API changes under active development, temporarily use a path dependency to `packages/driver-api`.
+
+The Driver itself remains an independent project; only the API source of truth lives in the DataZen monorepo.

--- a/packages/driver-api/README.md
+++ b/packages/driver-api/README.md
@@ -10,11 +10,11 @@ The crate is maintained in the DataZen monorepo under `packages/driver-api` and 
 
 ## Usage
 
-A third-party driver normally depends on the published crate:
+The current crate version is `0.0.8`. A third-party driver can depend on the published release with:
 
 ```toml
 [dependencies]
-datazen-driver-api = "0.1"
+datazen-driver-api = "0.0.8"
 ```
 
 Then implement the public driver traits:
@@ -40,7 +40,7 @@ The Driver API is deliberately independent of database implementation libraries.
 
 Those implementation types must not appear in the public Driver API. Connection pools, rows, transactions, cursors, and database-specific errors remain private to the driver implementation. DataZen communicates through API-defined types such as `ConnectionHandle`, `QueryResult`, `Value`, and `DriverError`.
 
-See [`docs/public-api-dependency-boundary.md`](../../docs/public-api-dependency-boundary.md) for the complete dependency-boundary policy.
+See [`docs/driver-api/public-api-dependency-boundary.md`](../../docs/driver-api/public-api-dependency-boundary.md) for the complete dependency-boundary policy.
 
 ## Versioning
 


### PR DESCRIPTION
## Summary
- make `packages/driver-api` the single source of truth for `datazen-driver-api`
- publish the API crate from the DataZen monorepo instead of maintaining a separate Git repository
- license the Driver API separately under MIT while DataZen remains GPLv3
- add crates.io package metadata and crate README
- remove the legacy Git URL patch for `flyxl/datazen-driver-api`
- add a GitHub Actions workflow for validating and publishing the crate
- document the public API dependency boundary and independent-driver consumption model
- update both README files to point to the monorepo crate and crates.io

## Validation
- `packages/driver-api` remains a workspace member and DataZen continues to use the local path dependency
- crate version remains `0.0.8` so the existing workspace lockfile does not require a generated update
- CI workflow runs `cargo check`, `cargo test`, `cargo package`, and `cargo publish --locked`

The first crates.io publication should be performed after this PR is merged, using the repository's `CARGO_REGISTRY_TOKEN` secret.