### PR TITLE
fix(redis): bound test connections and disable implicit TLS

### DIFF
--- a/packages/drivers/redis/src/redis_driver.rs
+++ b/packages/drivers/redis/src/redis_driver.rs
@@ -10,7 +10,7 @@ use datazen_driver_api::*;
 use redis::AsyncCommands;
 use redis::FromRedisValue;
 use std::collections::HashMap;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
 
 use crate::connect::{
@@ -86,6 +86,8 @@ macro_rules! plugin_on_db {
 pub struct RedisDriver {
     connections: RwLock<HashMap<String, RedisConn>>,
 }
+
+const TEST_CONNECTION_TLS_GRACE: Duration = Duration::from_secs(5);
 
 impl RedisDriver {
     pub fn new() -> Self {
@@ -209,6 +211,37 @@ impl RedisDriver {
     pub async fn plugin_flush_all(&self, connection_id: &str) -> Result<(), DriverError> {
         with_live_any_op!(self, connection_id, |conn| crate::ops::flush_all(conn)
             .await)
+    }
+
+    async fn test_connection_inner(
+        &self,
+        config: &ConnectionConfig,
+    ) -> Result<ServerInfo, DriverError> {
+        let plan = build_connection_plan(config)?;
+        let mut live = open_live_conn(&plan).await?;
+        if let ConnectionPlan::Standalone(p) = &plan {
+            Self::select_db(&mut live, p.db_index)
+                .await
+                .map_err(DriverError::QueryFailed)?;
+        } else if let ConnectionPlan::Sentinel(p) = &plan {
+            Self::select_db(&mut live, p.db_index)
+                .await
+                .map_err(DriverError::QueryFailed)?;
+        }
+
+        let info: String = with_redis_conn!(&mut live, |conn| info_server_on(conn).await)
+            .map_err(DriverError::QueryFailed)?;
+
+        let version = info
+            .lines()
+            .find(|l| l.starts_with("redis_version:"))
+            .map(|l| l.trim_start_matches("redis_version:").trim().to_string())
+            .unwrap_or_else(|| "unknown".into());
+
+        Ok(ServerInfo {
+            server_version: version,
+            server_type: "Redis".into(),
+        })
     }
 
     pub async fn plugin_info(
@@ -1120,31 +1153,15 @@ impl DatabaseDriver for RedisDriver {
     }
 
     async fn test_connection(&self, config: &ConnectionConfig) -> Result<ServerInfo, DriverError> {
-        let plan = build_connection_plan(config)?;
-        let mut live = open_live_conn(&plan).await?;
-        if let ConnectionPlan::Standalone(p) = &plan {
-            Self::select_db(&mut live, p.db_index)
-                .await
-                .map_err(DriverError::QueryFailed)?;
-        } else if let ConnectionPlan::Sentinel(p) = &plan {
-            Self::select_db(&mut live, p.db_index)
-                .await
-                .map_err(DriverError::QueryFailed)?;
-        }
-
-        let info: String = with_redis_conn!(&mut live, |conn| info_server_on(conn).await)
-            .map_err(DriverError::QueryFailed)?;
-
-        let version = info
-            .lines()
-            .find(|l| l.starts_with("redis_version:"))
-            .map(|l| l.trim_start_matches("redis_version:").trim().to_string())
-            .unwrap_or_else(|| "unknown".into());
-
-        Ok(ServerInfo {
-            server_version: version,
-            server_type: "Redis".into(),
-        })
+        let timeout = Duration::from_secs(config.connection_timeout.max(1) as u64)
+            .saturating_add(TEST_CONNECTION_TLS_GRACE);
+        tokio::time::timeout(timeout, self.test_connection_inner(config))
+            .await
+            .map_err(|_| {
+                DriverError::ConnectionFailed(format!(
+                    "Redis test connection timed out after {timeout:?}"
+                ))
+            })?
     }
 
     async fn connect(&self, config: &ConnectionConfig) -> Result<ConnectionHandle, DriverError> {
@@ -1687,4 +1704,60 @@ fn looks_like_hash(items: &[redis::Value]) -> bool {
             redis::Value::BulkString(_) | redis::Value::SimpleString(_)
         )
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    fn config_for(port: u16) -> ConnectionConfig {
+        ConnectionConfig {
+            id: "redis-test".into(),
+            name: "redis-test".into(),
+            database_type: "redis".into(),
+            host: Some("127.0.0.1".into()),
+            port: Some(port),
+            database: Some("0".into()),
+            schema: None,
+            username: None,
+            password: None,
+            ssl_mode: SslMode::Disable,
+            connection_timeout: 1,
+            max_pool_size: 10,
+            ssh_tunnel: None,
+            color_tag: None,
+            group: None,
+            last_connected_at: None,
+            server_version: None,
+            read_only: false,
+            pinned: false,
+            options: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_connection_times_out_when_server_stops_responding() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                return;
+            };
+            let mut buf = [0; 1024];
+            let _ = socket.read(&mut buf).await;
+            let _ = socket.write_all(b"+OK\r\n").await;
+            tokio::time::sleep(Duration::from_secs(30)).await;
+        });
+
+        let started = Instant::now();
+        let err = RedisDriver::new()
+            .test_connection(&config_for(port))
+            .await
+            .unwrap_err();
+
+        assert!(started.elapsed() < Duration::from_secs(8));
+        assert!(err.to_string().contains("timed out"));
+    }
 }

--- a/packages/drivers/redis/ui/ConnectionWizard.tsx
+++ b/packages/drivers/redis/ui/ConnectionWizard.tsx
@@ -326,7 +326,10 @@ export function RedisTlsFields({ form }: { form: ConnectionFormState }) {
         <input
           type="checkbox"
           checked={redisOptions.tls?.enabled === true}
-          onChange={(e) => updateOptions({ tls: { enabled: e.target.checked } })}
+          onChange={(e) => {
+            updateOptions({ tls: { enabled: e.target.checked } });
+            form.setSslMode(e.target.checked ? 'require' : 'disable');
+          }}
         />
         <span>{t('redis.wizard.tlsEnabled')}</span>
       </label>

--- a/packages/drivers/redis/ui/__tests__/connectionWizard.test.tsx
+++ b/packages/drivers/redis/ui/__tests__/connectionWizard.test.tsx
@@ -273,6 +273,7 @@ describe('RedisTlsFields', () => {
     fireEvent.click(checkboxes[0]);
     fireEvent.click(checkboxes[1]);
     expect(form.setOptions).toHaveBeenCalled();
+    expect(form.setSslMode).toHaveBeenCalledWith('disable');
     fireEvent.change(screen.getByPlaceholderText('/path/to/ca.pem'), {
       target: { value: '/tmp/ca.pem' },
     });

--- a/packages/drivers/redis/ui/meta.ts
+++ b/packages/drivers/redis/ui/meta.ts
@@ -12,6 +12,7 @@ export const redisMeta = {
     connectionMode: 'server',
     supportsSSH: true,
     supportsSSL: true,
+    defaultSslMode: 'disable',
     supportsBackup: false,
     supportsTables: false,
     isKeyValue: true,

--- a/src/components/connection/__tests__/useConnectionForm.test.ts
+++ b/src/components/connection/__tests__/useConnectionForm.test.ts
@@ -99,10 +99,11 @@ describe('useConnectionForm', () => {
     expect(result.current.database).toBe('');
     expect(result.current.username).toBe('');
 
-    // Switch to Redis: database should be '0'
+    // Switch to Redis: database should be '0' and TLS should stay off for plaintext Redis.
     if (DB_REGISTRY.redis) {
       act(() => result.current.handleDatabaseTypeChange('redis'));
       expect(result.current.database).toBe('0');
+      expect(result.current.sslMode).toBe('disable');
     }
 
     // Switch back to PostgreSQL: database should be 'postgres', username 'postgres'
@@ -110,6 +111,31 @@ describe('useConnectionForm', () => {
     expect(result.current.database).toBe('postgres');
     expect(result.current.username).toBe('postgres');
     expect(result.current.port).toBe('5432');
+  });
+
+  it('normalizes legacy redis prefer SSL to disabled when TLS is unchecked', () => {
+    if (!DB_REGISTRY.redis) return;
+
+    const { result } = renderHook(() =>
+      useConnectionForm({
+        editId: 'redis-old',
+        existingConnections: [
+          {
+            id: 'redis-old',
+            name: 'redis-old',
+            databaseType: 'redis',
+            host: '127.0.0.1',
+            port: 6379,
+            database: '0',
+            sslMode: 'prefer',
+            options: { topology: 'standalone' },
+          },
+        ],
+      }),
+    );
+
+    expect(result.current.sslMode).toBe('prefer');
+    expect(result.current.draft.sslMode).toBe('disable');
   });
 
   it('includes username in kiwi draft', () => {

--- a/src/components/connection/useConnectionForm.ts
+++ b/src/components/connection/useConnectionForm.ts
@@ -14,6 +14,16 @@ export interface UseConnectionFormOptions {
   onAfterSave?: () => void;
 }
 
+function hasEnabledTlsOption(options: Record<string, unknown>): boolean {
+  const tls = options.tls;
+  return Boolean(
+    tls &&
+      typeof tls === 'object' &&
+      !Array.isArray(tls) &&
+      (tls as { enabled?: unknown }).enabled === true,
+  );
+}
+
 export function useConnectionForm(options: UseConnectionFormOptions = {}) {
   const { editId, existingConnections, onAfterSave } = options;
   const { t } = useI18n();
@@ -122,6 +132,7 @@ export function useConnectionForm(options: UseConnectionFormOptions = {}) {
     setHost(meta.defaultHost || '127.0.0.1');
     setPort(meta.defaultPort ? String(meta.defaultPort) : '');
     setUsername(meta.defaultUser || '');
+    setSslMode(meta.defaultSslMode ?? 'prefer');
 
     if (!meta.supportsSSH) setSshEnabled(false);
 
@@ -197,18 +208,22 @@ export function useConnectionForm(options: UseConnectionFormOptions = {}) {
   }, [connectionOptions, database, formVariant, host, isPluginForm, meta?.connectionMode, password, port, schema, t, username]);
 
   const draft = useMemo((): ConnectionConfig => {
+    const draftMeta = DB_REGISTRY[databaseType];
+    const effectiveSslMode =
+      draftMeta?.defaultSslMode === 'disable' && !hasEnabledTlsOption(connectionOptions)
+        ? 'disable'
+        : sslMode;
     const base: ConnectionConfig = {
       id: editId ?? newId(),
       name: name || t('newConn.unnamed'),
       databaseType,
-      sslMode,
+      sslMode: effectiveSslMode,
       group: group || undefined,
       colorTag: colorTag || undefined,
       sshTunnel,
       readOnly: readOnly || undefined,
     };
 
-    const draftMeta = DB_REGISTRY[databaseType];
     if (!draftMeta || draftMeta.connectionMode === 'file') {
       return { ...base, database };
     }

--- a/src/lib/databaseMeta.ts
+++ b/src/lib/databaseMeta.ts
@@ -3,7 +3,7 @@
  * Extracted to avoid circular deps between types/index.ts ↔ plugins/generated.ts.
  */
 
-import type { DatabaseObjectKind } from '../types';
+import type { DatabaseObjectKind, SslMode } from '../types';
 import type { StructureEditorUiConfig } from './structureEditor/types';
 
 export type ConnectionMode = 'server' | 'file' | 'url';
@@ -35,6 +35,8 @@ export interface DatabaseTypeMeta {
   supportsSSH: boolean;
   /** Whether SSL/TLS configuration is supported */
   supportsSSL: boolean;
+  /** Default SSL/TLS mode when switching to this database type */
+  defaultSslMode?: SslMode;
   /** Whether database backup is supported */
   supportsBackup: boolean;
   /** Whether this type supports schemas (tables, queries, etc.) */


### PR DESCRIPTION
## Summary

- default Redis connections to plaintext unless the Redis TLS option is explicitly enabled, including legacy connections saved with hidden `sslMode: prefer`
- keep the Redis TLS checkbox and the shared SSL mode in sync
- bound the complete Redis connection test, including `SELECT` and `INFO`, so an unresponsive endpoint cannot leave the UI testing forever

## Test plan

- [ ] `pnpm test:unit` — current `main` has 10 unrelated failures in `QueryPanel`/`ConnectionPage` mocks (`estimateExpandedToolbarWidth` and Tauri window mocks); Redis-focused tests pass
- [ ] `cargo test -p datazen --lib` — current `main` has one unrelated failure in `connect_dedicated_opens_separate_session_from_reuse` (`mock-d1 == mock-d1`)
- [x] `cargo test -p datazen-ai-api --lib`
- [ ] `node scripts/check-site-seo.mjs` — current `main` tracks `site/assets/video`, while the check requires that directory not to exist
- [x] Manual / E2E checks: launched `pnpm tauri:dev --drivers=basic`; exercised the DataZen Redis driver against a real authenticated plaintext Redis endpoint; verified successful connection without exposing credentials
- [x] `cargo test -p datazen-driver-redis`
- [x] Redis driver UI tests and connection form tests
- [x] `pnpm typecheck`

## Checklist

- [x] I followed CONTRIBUTING.md
- [x] No secrets or credentials in the diff
- [x] Docs / i18n updated if user-facing behavior changed (not applicable; no user-facing text changed)
