### PR TITLE
fix(query): path-hierarchy context, navigator expand keys, and searchable Select

### DIFF
--- a/src/components/query/QueryContextSelectors.tsx
+++ b/src/components/query/QueryContextSelectors.tsx
@@ -1,7 +1,10 @@
+import { Fragment } from 'react';
 import { Database } from 'lucide-react';
 import { Select } from '../ui/Select';
-import { namespaceBranchChildNames, type SqlNamespace } from '../../lib/sqlNamespace';
-import { namespaceRootsFrom } from '../../lib/queryContextPath';
+import {
+  buildPathHierarchySelectorSegments,
+  pathHierarchySelectorSegmentsForUi,
+} from '../../lib/queryContextPath';
 import { useI18n } from '../../hooks/useI18n';
 
 export interface QueryContextSelectorsProps {
@@ -9,7 +12,7 @@ export interface QueryContextSelectorsProps {
   isPathHierarchy: boolean;
   databases: readonly string[];
   currentDatabase: string | null;
-  namespaceTree: SqlNamespace;
+  namespaceTree: import('../../lib/sqlNamespace').SqlNamespace;
   pathAliases: Record<string, string>;
   contextPath: readonly string[];
   contextSchema?: string | null;
@@ -29,6 +32,10 @@ function levelLabelKey(
   return 'query.schema';
 }
 
+const PATH_HIERARCHY_SELECT_CLASS =
+  '!h-6 !text-[11px] shrink-0 !w-auto !min-w-[4rem] !max-w-[5.5rem]';
+const PATH_HIERARCHY_SELECTORS_MIN_WIDTH = 'min-w-[9rem]';
+
 export function QueryContextSelectors({
   isMultiDb,
   isPathHierarchy,
@@ -43,30 +50,54 @@ export function QueryContextSelectors({
   const { t } = useI18n();
 
   if (isPathHierarchy) {
-    const roots = namespaceRootsFrom(namespaceTree, pathAliases, databases);
-    if (roots.length === 0) return null;
-
-    const levels: Array<{ options: string[]; value: string }> = [];
-    levels.push({ options: roots, value: contextPath[0] ?? '' });
-    for (let i = 0; i < contextPath.length; i++) {
-      const children = namespaceBranchChildNames(namespaceTree, [...contextPath.slice(0, i + 1)]);
-      if (children.length === 0) break;
-      levels.push({ options: children, value: contextPath[i + 1] ?? '' });
-    }
+    const segments = pathHierarchySelectorSegmentsForUi(
+      namespaceTree,
+      pathAliases,
+      databases,
+      contextPath,
+    );
 
     return (
-      <div className="flex shrink-0 items-center gap-1.5" data-testid="query-context-selectors">
-        <Database className="h-3.5 w-3.5 text-fg-muted" />
-        {levels.map((level, index) => (
-          <Select
-            key={`${index}-${level.value}`}
-            value={level.value}
-            options={level.options.map((name) => ({ value: name, label: name }))}
-            onChange={(value) => onSelectLevel(index, value)}
-            placeholder={t(levelLabelKey(index, true))}
-            className="!h-6 !text-[11px] max-w-[180px]"
-            title={t(levelLabelKey(index, true))}
-          />
+      <div
+        className={`flex shrink-0 items-center gap-0.5 ${PATH_HIERARCHY_SELECTORS_MIN_WIDTH}`}
+        data-testid="query-context-selectors"
+      >
+        <Database className="h-3.5 w-3.5 shrink-0 text-fg-muted" />
+        {segments.map((segment, index) => (
+          <Fragment
+            key={
+              segment.kind === 'label'
+                ? `label-${index}-${segment.name}`
+                : `select-${segment.levelIndex}`
+            }
+          >
+            {index > 0 && (
+              <span className="px-0.5 text-[10px] text-fg-muted/70" aria-hidden="true">
+                /
+              </span>
+            )}
+            {segment.kind === 'label' ? (
+              <span
+                className="max-w-[4.5rem] truncate text-[11px] text-fg-muted"
+                title={segment.name}
+                data-testid="query-context-path-label"
+              >
+                {segment.name}
+              </span>
+            ) : (
+              <Select
+                value={segment.value}
+                options={segment.options.map((name) => ({ value: name, label: name }))}
+                onChange={(value) => onSelectLevel(segment.levelIndex, value)}
+                placeholder={t(levelLabelKey(segment.levelIndex, true))}
+                className={PATH_HIERARCHY_SELECT_CLASS}
+                title={t(levelLabelKey(segment.levelIndex, true))}
+                searchable
+                fitContent
+                disabled={segment.options.length === 0}
+              />
+            )}
+          </Fragment>
         ))}
       </div>
     );
@@ -84,6 +115,7 @@ export function QueryContextSelectors({
           onChange={(db) => onSelectLevel(0, db)}
           className="!h-6 !text-[11px] max-w-[180px]"
           title={t('query.database')}
+          searchable
         />
       )}
       {contextSchema && (

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { ChevronDown } from 'lucide-react';
 import { cn } from '../../lib/cn';
@@ -18,51 +18,161 @@ export interface SelectProps {
   readonly disabled?: boolean;
   readonly className?: string;
   readonly title?: string;
+  /** Combobox: type in the trigger field to filter options by label or value. */
+  readonly searchable?: boolean;
+  /** Shrink trigger width to the current label/query; pair with `max-w-*` on `className`. */
+  readonly fitContent?: boolean;
 }
 
 const LIST_ID = 'dz-select-listbox';
 
-export function Select({ value, options, onChange, placeholder, disabled, className, title }: SelectProps) {
+function filterOptions(options: readonly SelectOption[], query: string): SelectOption[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [...options];
+  return options.filter(
+    (o) => o.label.toLowerCase().includes(q) || o.value.toLowerCase().includes(q),
+  );
+}
+
+const triggerShellClass =
+  'flex items-center rounded-md border border-edge bg-surface text-left text-sm text-fg outline-none focus-within:border-blue-500 focus-within:ring-2 focus-within:ring-blue-500/25 disabled:cursor-not-allowed disabled:opacity-50';
+
+function fitContentCharCount(text: string, min = 2, max = 12): number {
+  return Math.max(min, Math.min(text.length, max));
+}
+
+function OptionList({
+  filteredOptions,
+  strValue,
+  highlightIdx,
+  setHighlightIdx,
+  handleSelect,
+}: {
+  filteredOptions: SelectOption[];
+  strValue: string;
+  highlightIdx: number;
+  setHighlightIdx: (idx: number) => void;
+  handleSelect: (opt: SelectOption) => void;
+}) {
+  if (filteredOptions.length === 0) {
+    return <div className="px-2.5 py-2 text-sm text-fg-muted">No matches</div>;
+  }
+  return (
+    <>
+      {filteredOptions.map((opt, idx) => {
+        const isSelected = opt.value === strValue;
+        const isHighlighted = idx === highlightIdx;
+        return (
+          <div
+            key={opt.value}
+            data-option-idx={idx}
+            tabIndex={opt.disabled ? undefined : -1}
+            aria-selected={isSelected}
+            title={opt.title}
+            className={cn(
+              'flex cursor-pointer items-center px-2.5 py-1.5 text-sm transition-colors',
+              opt.disabled && 'cursor-not-allowed opacity-40',
+              isHighlighted && !opt.disabled && 'bg-surface-raised',
+              isSelected && !isHighlighted && 'text-accent',
+            )}
+            onMouseEnter={() => {
+              if (!opt.disabled) setHighlightIdx(idx);
+            }}
+            onMouseDown={(e) => {
+              e.preventDefault();
+              handleSelect(opt);
+            }}
+          >
+            <span className="min-w-0 truncate">{opt.label}</span>
+            {isSelected && <span className="ml-auto pl-2 text-accent">✓</span>}
+          </div>
+        );
+      })}
+    </>
+  );
+}
+
+export function Select({
+  value,
+  options,
+  onChange,
+  placeholder,
+  disabled,
+  className,
+  title,
+  searchable = false,
+  fitContent = false,
+}: SelectProps) {
   const [open, setOpen] = useState(false);
   const [highlightIdx, setHighlightIdx] = useState(-1);
-  const triggerRef = useRef<HTMLButtonElement>(null);
+  const [filterQuery, setFilterQuery] = useState('');
+  const triggerRef = useRef<HTMLDivElement | HTMLButtonElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
   const [pos, setPos] = useState<{ top: number; left: number; width: number }>({
-    top: 0, left: 0, width: 0,
+    top: 0,
+    left: 0,
+    width: 0,
   });
 
   const strValue = String(value);
   const selectedOption = options.find((o) => o.value === strValue);
+
+  const filteredOptions = useMemo(
+    () => (searchable ? filterOptions(options, filterQuery) : [...options]),
+    [options, filterQuery, searchable],
+  );
 
   const updatePosition = useCallback(() => {
     if (!triggerRef.current) return;
     const rect = triggerRef.current.getBoundingClientRect();
     const spaceBelow = globalThis.innerHeight - rect.bottom;
     const spaceAbove = rect.top;
-    const listHeight = Math.min(options.length * 34 + 8, 240);
+    const listHeight = Math.min(filteredOptions.length * 34 + 8, 240);
     const goUp = spaceBelow < listHeight && spaceAbove > spaceBelow;
     setPos({
       top: goUp ? rect.top - listHeight - 4 : rect.bottom + 4,
       left: rect.left,
       width: rect.width,
     });
-  }, [options.length]);
+  }, [filteredOptions.length]);
+
+  const pickHighlightIndex = useCallback(
+    (list: readonly SelectOption[]) => {
+      const enabled = list.filter((o) => !o.disabled);
+      const idx = enabled.findIndex((o) => o.value === strValue);
+      if (idx >= 0) return list.indexOf(enabled[idx]);
+      return list.findIndex((o) => !o.disabled);
+    },
+    [strValue],
+  );
 
   const handleOpen = useCallback(() => {
     if (disabled) return;
     updatePosition();
+    setFilterQuery('');
     setOpen(true);
-    const enabledOptions = options.filter((o) => !o.disabled);
-    const idx = enabledOptions.findIndex((o) => o.value === strValue);
-    setHighlightIdx(idx >= 0 ? options.indexOf(enabledOptions[idx]) : 0);
-  }, [disabled, updatePosition, options, strValue]);
+    setHighlightIdx(pickHighlightIndex(filterOptions(options, '')));
+  }, [disabled, updatePosition, options, pickHighlightIndex]);
 
-  const handleSelect = useCallback((opt: SelectOption) => {
-    if (opt.disabled) return;
-    onChange(opt.value);
+  const handleClose = useCallback(() => {
     setOpen(false);
-    triggerRef.current?.focus();
-  }, [onChange]);
+    setFilterQuery('');
+  }, []);
+
+  const handleSelect = useCallback(
+    (opt: SelectOption) => {
+      if (opt.disabled) return;
+      onChange(opt.value);
+      handleClose();
+      if (searchable) {
+        inputRef.current?.focus();
+      } else {
+        (triggerRef.current as HTMLButtonElement | null)?.focus();
+      }
+    },
+    [onChange, handleClose, searchable],
+  );
 
   useEffect(() => {
     if (!open) return;
@@ -70,20 +180,172 @@ export function Select({ value, options, onChange, placeholder, disabled, classN
       if (
         triggerRef.current?.contains(e.target as Node) ||
         listRef.current?.contains(e.target as Node)
-      ) return;
-      setOpen(false);
+      )
+        return;
+      handleClose();
     };
     globalThis.addEventListener('mousedown', handler);
     return () => globalThis.removeEventListener('mousedown', handler);
-  }, [open]);
+  }, [open, handleClose]);
+
+  useEffect(() => {
+    if (!open) return;
+    updatePosition();
+    if (searchable) {
+      inputRef.current?.focus();
+    }
+  }, [open, searchable, updatePosition]);
+
+  useEffect(() => {
+    if (!open) return;
+    setHighlightIdx(pickHighlightIndex(filteredOptions));
+  }, [filterQuery, open, filteredOptions, pickHighlightIndex]);
 
   useEffect(() => {
     if (!open || highlightIdx < 0 || !listRef.current) return;
-    const item = listRef.current.children[highlightIdx] as HTMLElement | undefined;
+    const item = listRef.current.querySelector(`[data-option-idx="${highlightIdx}"]`) as
+      | HTMLElement
+      | undefined;
     item?.scrollIntoView?.({ block: 'nearest' });
-  }, [open, highlightIdx]);
+  }, [open, highlightIdx, filteredOptions]);
 
-  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+  const moveHighlight = useCallback(
+    (direction: 1 | -1) => {
+      if (filteredOptions.length === 0) return;
+      let next =
+        highlightIdx < 0 ? (direction === 1 ? 0 : filteredOptions.length - 1) : highlightIdx;
+      for (let i = 0; i < filteredOptions.length; i += 1) {
+        next = (next + direction + filteredOptions.length) % filteredOptions.length;
+        if (!filteredOptions[next]?.disabled) break;
+      }
+      setHighlightIdx(next);
+    },
+    [filteredOptions, highlightIdx],
+  );
+
+  const handleListKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!open) return;
+      switch (e.key) {
+        case 'ArrowDown': {
+          e.preventDefault();
+          moveHighlight(1);
+          break;
+        }
+        case 'ArrowUp': {
+          e.preventDefault();
+          moveHighlight(-1);
+          break;
+        }
+        case 'Enter': {
+          e.preventDefault();
+          const opt = filteredOptions[highlightIdx];
+          if (opt && !opt.disabled) handleSelect(opt);
+          break;
+        }
+        case 'Escape':
+        case 'Tab':
+          handleClose();
+          break;
+      }
+    },
+    [open, highlightIdx, filteredOptions, handleSelect, handleClose, moveHighlight],
+  );
+
+  const listPortal =
+    open &&
+    createPortal(
+      <div
+        ref={listRef}
+        id={LIST_ID}
+        className="fixed z-[9999] overflow-y-auto rounded-lg border border-edge bg-surface-alt py-1 shadow-xl"
+        style={{ top: pos.top, left: pos.left, width: pos.width, maxHeight: 240 }}
+        onKeyDown={handleListKeyDown}
+      >
+        <OptionList
+          filteredOptions={filteredOptions}
+          strValue={strValue}
+          highlightIdx={highlightIdx}
+          setHighlightIdx={setHighlightIdx}
+          handleSelect={handleSelect}
+        />
+      </div>,
+      document.body,
+    );
+
+  if (searchable) {
+    const editing = open || filterQuery.length > 0;
+    const inputValue = editing ? filterQuery : (selectedOption?.label ?? '');
+    const showPlaceholder = !editing && !selectedOption;
+    const sizingText = editing ? filterQuery : (selectedOption?.label ?? placeholder ?? '');
+    const fitMinChars = fitContent ? Math.max(6, Math.min(placeholder?.length ?? 6, 12)) : 2;
+    const inputCh = fitContent ? fitContentCharCount(sizingText, fitMinChars) : undefined;
+
+    return (
+      <>
+        <div
+          ref={triggerRef as React.RefObject<HTMLDivElement>}
+          title={title}
+          className={cn(
+            triggerShellClass,
+            fitContent ? 'inline-flex w-auto' : 'w-full',
+            'h-9 gap-0.5',
+            className,
+          )}
+        >
+          <input
+            ref={inputRef}
+            type="text"
+            disabled={disabled}
+            aria-expanded={open}
+            aria-haspopup="listbox"
+            aria-controls={open ? LIST_ID : undefined}
+            aria-autocomplete="list"
+            className={cn(
+              'bg-transparent outline-none',
+              fitContent ? 'shrink-0 pl-2.5 pr-0' : 'min-w-0 flex-1 px-2.5',
+              showPlaceholder && 'text-fg-muted',
+            )}
+            style={inputCh !== undefined ? { width: `${inputCh}ch` } : undefined}
+            value={inputValue}
+            placeholder={showPlaceholder ? (placeholder ?? '') : undefined}
+            onChange={(e) => {
+              setFilterQuery(e.target.value);
+              if (!open) {
+                updatePosition();
+                setOpen(true);
+                setHighlightIdx(pickHighlightIndex(filterOptions(options, e.target.value)));
+              }
+            }}
+            onFocus={() => {
+              if (!open) handleOpen();
+            }}
+            onKeyDown={(e) => {
+              if (!open && (e.key === 'ArrowDown' || e.key === 'ArrowUp')) {
+                e.preventDefault();
+                handleOpen();
+                return;
+              }
+              handleListKeyDown(e);
+            }}
+          />
+          <button
+            type="button"
+            disabled={disabled}
+            aria-label="Toggle options"
+            className="flex shrink-0 items-center justify-center self-stretch px-1 text-fg-muted hover:text-fg disabled:pointer-events-none"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => (open ? handleClose() : handleOpen())}
+          >
+            <ChevronDown className={cn('h-3.5 w-3.5 transition-transform', open && 'rotate-180')} />
+          </button>
+        </div>
+        {listPortal}
+      </>
+    );
+  }
+
+  const handleButtonKeyDown = (e: React.KeyboardEvent) => {
     if (!open) {
       if (e.key === 'ArrowDown' || e.key === 'ArrowUp' || e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();
@@ -91,40 +353,16 @@ export function Select({ value, options, onChange, placeholder, disabled, classN
       }
       return;
     }
+    handleListKeyDown(e);
+  };
 
-    switch (e.key) {
-      case 'ArrowDown': {
-        e.preventDefault();
-        let next = highlightIdx;
-        do { next = (next + 1) % options.length; } while (options[next].disabled && next !== highlightIdx);
-        setHighlightIdx(next);
-        break;
-      }
-      case 'ArrowUp': {
-        e.preventDefault();
-        let next = highlightIdx;
-        do { next = (next - 1 + options.length) % options.length; } while (options[next].disabled && next !== highlightIdx);
-        setHighlightIdx(next);
-        break;
-      }
-      case 'Enter':
-      case ' ': {
-        e.preventDefault();
-        const opt = options[highlightIdx];
-        if (opt && !opt.disabled) handleSelect(opt);
-        break;
-      }
-      case 'Escape':
-      case 'Tab':
-        setOpen(false);
-        break;
-    }
-  }, [open, highlightIdx, options, handleOpen, handleSelect]);
+  const buttonSizingText = selectedOption?.label ?? placeholder ?? '';
+  const buttonFitMinChars = fitContent ? Math.max(6, Math.min(placeholder?.length ?? 6, 12)) : 2;
 
   return (
     <>
       <button
-        ref={triggerRef}
+        ref={triggerRef as React.RefObject<HTMLButtonElement>}
         type="button"
         aria-expanded={open}
         aria-haspopup="listbox"
@@ -132,53 +370,35 @@ export function Select({ value, options, onChange, placeholder, disabled, classN
         disabled={disabled}
         title={title}
         className={cn(
-          'flex h-9 w-full items-center justify-between gap-1 rounded-md border border-edge bg-surface px-2.5 text-left text-sm text-fg outline-none',
-          'focus:border-blue-500 focus:ring-2 focus:ring-blue-500/25',
-          'disabled:cursor-not-allowed disabled:opacity-50',
+          triggerShellClass,
+          fitContent ? 'inline-flex w-auto' : 'w-full',
+          'h-9 justify-between gap-1 px-2.5',
           className,
         )}
-        onClick={() => (open ? setOpen(false) : handleOpen())}
-        onKeyDown={handleKeyDown}
+        onClick={() => (open ? handleClose() : handleOpen())}
+        onKeyDown={handleButtonKeyDown}
       >
-        <span className={cn('min-w-0 truncate', !selectedOption && 'text-fg-muted')}>
+        <span
+          className={cn(
+            fitContent ? 'shrink-0 truncate' : 'min-w-0 truncate',
+            !selectedOption && 'text-fg-muted',
+          )}
+          style={
+            fitContent
+              ? { width: `${fitContentCharCount(buttonSizingText, buttonFitMinChars)}ch` }
+              : undefined
+          }
+        >
           {selectedOption?.label ?? placeholder ?? ''}
         </span>
-        <ChevronDown className={cn('h-3.5 w-3.5 shrink-0 text-fg-muted transition-transform', open && 'rotate-180')} />
+        <ChevronDown
+          className={cn(
+            'h-3.5 w-3.5 shrink-0 text-fg-muted transition-transform',
+            open && 'rotate-180',
+          )}
+        />
       </button>
-
-      {open && createPortal(
-        <div
-          ref={listRef}
-          id={LIST_ID}
-          className="fixed z-[9999] overflow-y-auto rounded-lg border border-edge bg-surface-alt py-1 shadow-xl"
-          style={{ top: pos.top, left: pos.left, width: pos.width, maxHeight: 240 }}
-        >
-          {options.map((opt, idx) => {
-            const isSelected = opt.value === strValue;
-            const isHighlighted = idx === highlightIdx;
-            return (
-              <div
-                key={opt.value}
-                tabIndex={opt.disabled ? undefined : -1}
-                aria-selected={isSelected}
-                title={opt.title}
-                className={cn(
-                  'flex cursor-pointer items-center px-2.5 py-1.5 text-sm transition-colors',
-                  opt.disabled && 'cursor-not-allowed opacity-40',
-                  isHighlighted && !opt.disabled && 'bg-surface-raised',
-                  isSelected && !isHighlighted && 'text-accent',
-                )}
-                onMouseEnter={() => { if (!opt.disabled) setHighlightIdx(idx); }}
-                onMouseDown={(e) => { e.preventDefault(); handleSelect(opt); }}
-              >
-                <span className="min-w-0 truncate">{opt.label}</span>
-                {isSelected && <span className="ml-auto pl-2 text-accent">✓</span>}
-              </div>
-            );
-          })}
-        </div>,
-        document.body,
-      )}
+      {listPortal}
     </>
   );
 }

--- a/src/components/ui/__tests__/Select.test.tsx
+++ b/src/components/ui/__tests__/Select.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import type { SelectOption } from '../Select';
+
+function filterOptions(options: readonly SelectOption[], query: string): SelectOption[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [...options];
+  return options.filter(
+    (o) => o.label.toLowerCase().includes(q) || o.value.toLowerCase().includes(q),
+  );
+}
+
+describe('Select filter', () => {
+  const options: SelectOption[] = [
+    { value: 'hive', label: 'hive' },
+    { value: 'snap', label: 'snap' },
+    { value: '558:presto_afi_data', label: 'presto_afi_data' },
+  ];
+
+  it('matches label and value substrings case-insensitively', () => {
+    expect(filterOptions(options, 'HIVE').map((o) => o.value)).toEqual(['hive']);
+    expect(filterOptions(options, 'presto').map((o) => o.value)).toEqual(['558:presto_afi_data']);
+    expect(filterOptions(options, '558').map((o) => o.value)).toEqual(['558:presto_afi_data']);
+  });
+
+  it('returns all options when query is empty', () => {
+    expect(filterOptions(options, '')).toHaveLength(3);
+  });
+});

--- a/src/lib/__tests__/connectionLocator.test.ts
+++ b/src/lib/__tests__/connectionLocator.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import type { ConnectionSchemaState } from '../../stores/schemaStore';
 import type { ConnectionConfig } from '../../types';
 import {
+  connectionExpandKey,
   groupConnectionsWithRecentSections,
+  parseConnectionExpandKey,
   PINNED_GROUP_KEY,
   rankConnections,
   RECENT_GROUP_KEY,
@@ -74,31 +76,27 @@ describe('rankConnections', () => {
   });
 
   it('preserves cached schema, table, path, and database-object matching', () => {
-    const result = rankConnections(
-      [connection({ id: 'cached' })],
-      'function_name',
-      {
-        activeConnections: {
-          cached: { status: 'connected', dbSessionId: 'session-1' },
-        },
-        schemas: new Map([
-          [
-            'session-1',
-            schemaState({
-              schemaNames: ['public'],
-              namespaceTree: { public: { users: [] } },
-              pathItems: { catalog: [{ name: 'path_table', tableType: 'table' }] },
-            }),
-          ],
-        ]),
-        dbTablesMap: {
-          'session-1::app': [{ name: 'cached_table', tableType: 'table', schema: 'public' }],
-        },
-        dbObjectsMap: {
-          'cached::app::functions': [{ kind: 'function', name: 'function_name', schema: 'public' }],
-        },
+    const result = rankConnections([connection({ id: 'cached' })], 'function_name', {
+      activeConnections: {
+        cached: { status: 'connected', dbSessionId: 'session-1' },
       },
-    );
+      schemas: new Map([
+        [
+          'session-1',
+          schemaState({
+            schemaNames: ['public'],
+            namespaceTree: { public: { users: [] } },
+            pathItems: { catalog: [{ name: 'path_table', tableType: 'table' }] },
+          }),
+        ],
+      ]),
+      dbTablesMap: {
+        'session-1::app': [{ name: 'cached_table', tableType: 'table', schema: 'public' }],
+      },
+      dbObjectsMap: {
+        'cached::app::functions': [{ kind: 'function', name: 'function_name', schema: 'public' }],
+      },
+    });
 
     expect(result).toHaveLength(1);
     expect(result[0]?.match).toEqual({
@@ -109,25 +107,31 @@ describe('rankConnections', () => {
   });
 
   it('uses match strength, pinned, recency, group, name, and id as stable keys', () => {
-    const result = rankConnections([
-      connection({ id: 'name-prefix', name: 'Prod app', pinned: true }),
-      connection({ id: 'name-exact', name: 'prod' }),
-      connection({
-        id: 'recent',
-        name: 'Recent app',
-        lastConnectedAt: '2026-08-30T10:00:00Z',
-      }),
-      connection({ id: 'old', name: 'Old app', lastConnectedAt: '2026-08-29T10:00:00Z' }),
-    ], 'prod');
+    const result = rankConnections(
+      [
+        connection({ id: 'name-prefix', name: 'Prod app', pinned: true }),
+        connection({ id: 'name-exact', name: 'prod' }),
+        connection({
+          id: 'recent',
+          name: 'Recent app',
+          lastConnectedAt: '2026-08-30T10:00:00Z',
+        }),
+        connection({ id: 'old', name: 'Old app', lastConnectedAt: '2026-08-29T10:00:00Z' }),
+      ],
+      'prod',
+    );
 
     expect(result.map(({ connection: item }) => item.id)).toEqual(['name-exact', 'name-prefix']);
 
-    const noSearch = rankConnections([
-      connection({ id: 'recent', name: 'Zed', lastConnectedAt: '2026-08-30T10:00:00Z' }),
-      connection({ id: 'pinned', name: 'Zulu', pinned: true }),
-      connection({ id: 'name', name: 'Alpha', group: 'dev' }),
-      connection({ id: 'older', name: 'Beta', lastConnectedAt: '2026-08-29T10:00:00Z' }),
-    ], '');
+    const noSearch = rankConnections(
+      [
+        connection({ id: 'recent', name: 'Zed', lastConnectedAt: '2026-08-30T10:00:00Z' }),
+        connection({ id: 'pinned', name: 'Zulu', pinned: true }),
+        connection({ id: 'name', name: 'Alpha', group: 'dev' }),
+        connection({ id: 'older', name: 'Beta', lastConnectedAt: '2026-08-29T10:00:00Z' }),
+      ],
+      '',
+    );
     expect(noSearch.map(({ connection: item }) => item.id)).toEqual([
       'pinned',
       'recent',
@@ -139,6 +143,17 @@ describe('rankConnections', () => {
   it('deduplicates connection ids in ranked search results', () => {
     const duplicate = connection({ id: 'same', name: 'Same' });
     expect(rankConnections([duplicate, { ...duplicate }], 'same')).toHaveLength(1);
+  });
+});
+
+describe('connectionExpandKey', () => {
+  it('scopes expand state per navigator section', () => {
+    expect(connectionExpandKey('__recent__', 'cfg-1')).toBe('__recent__::cfg-1');
+    expect(connectionExpandKey('prod', 'cfg-1')).toBe('prod::cfg-1');
+    expect(parseConnectionExpandKey('prod::cfg-1')).toEqual({
+      sectionGroup: 'prod',
+      connectionId: 'cfg-1',
+    });
   });
 });
 

--- a/src/lib/__tests__/queryContextPath.test.ts
+++ b/src/lib/__tests__/queryContextPath.test.ts
@@ -3,7 +3,14 @@ import {
   inferSqlRelationPath,
   namespaceRootsFrom,
   resolveQueryContextPath,
+  buildPathHierarchyDatabasePin,
+  splitPathHierarchyDatabasePin,
+  autoCompletePathHierarchyPath,
+  buildPathHierarchySelectorSegments,
+  pathHierarchySelectorSegmentsForUi,
+  PATH_HIERARCHY_PLACEHOLDER_SELECTOR_SEGMENTS,
 } from '../queryContextPath';
+import type { SqlNamespace } from '../sqlNamespace';
 
 describe('inferSqlRelationPath', () => {
   it('reads a MySQL-qualified table', () => {
@@ -80,6 +87,15 @@ describe('resolveQueryContextPath', () => {
     ).toEqual(['trading_dev']);
   });
 
+  it('resolves long Superset table names', () => {
+    expect(
+      resolveQueryContextPath('SELECT * FROM hive.snap.afi_id_loan_t_afi_installment_order', {
+        databases: ['558:presto_afi_data'],
+        namespaceRoots: ['hive'],
+      }),
+    ).toEqual(['hive', 'snap']);
+  });
+
   it('switches path-hierarchy as soon as catalog. or catalog.schema.', () => {
     expect(
       resolveQueryContextPath('SELECT * FROM hive.', {
@@ -103,5 +119,101 @@ describe('namespaceRootsFrom', () => {
       'hive',
       'pg',
     ]);
+  });
+});
+
+describe('buildPathHierarchyDatabasePin', () => {
+  it('joins connection root with catalog/schema segments', () => {
+    expect(buildPathHierarchyDatabasePin('558:presto_afi_data', ['hive', 'snap'])).toBe(
+      '558:presto_afi_data/hive/snap',
+    );
+  });
+
+  it('returns root when namespace path is empty', () => {
+    expect(buildPathHierarchyDatabasePin('558', [])).toBe('558');
+  });
+});
+
+describe('splitPathHierarchyDatabasePin', () => {
+  it('splits fetch paths from table-open context', () => {
+    expect(splitPathHierarchyDatabasePin('558/hive/snap')).toEqual({
+      root: '558',
+      namespacePath: ['hive', 'snap'],
+    });
+  });
+});
+
+const supersetTree: SqlNamespace = {
+  hive: { snap: {}, default: {} },
+  pg: { public: {} },
+};
+
+describe('autoCompletePathHierarchyPath', () => {
+  it('auto-picks a single root and single schema', () => {
+    expect(autoCompletePathHierarchyPath({ hive: { snap: {} } }, {}, ['558:presto'], [])).toEqual([
+      'hive',
+      'snap',
+    ]);
+  });
+
+  it('extends through single-option children after user picks catalog', () => {
+    expect(autoCompletePathHierarchyPath({ hive: { snap: {} } }, {}, [], ['hive'])).toEqual([
+      'hive',
+      'snap',
+    ]);
+  });
+
+  it('returns null when multiple roots and path is empty', () => {
+    expect(autoCompletePathHierarchyPath(supersetTree, {}, [], [])).toBeNull();
+  });
+
+  it('returns null when path already complete', () => {
+    expect(
+      autoCompletePathHierarchyPath({ hive: { snap: {} } }, {}, [], ['hive', 'snap']),
+    ).toBeNull();
+  });
+});
+
+describe('buildPathHierarchySelectorSegments', () => {
+  it('renders labels for single-option levels', () => {
+    expect(
+      buildPathHierarchySelectorSegments({ hive: { snap: {} } }, {}, [], ['hive', 'snap']),
+    ).toEqual([
+      { kind: 'label', name: 'hive' },
+      { kind: 'label', name: 'snap' },
+    ]);
+  });
+
+  it('shows select when multiple schemas exist', () => {
+    expect(
+      buildPathHierarchySelectorSegments({ hive: { snap: {}, default: {} } }, {}, [], ['hive']),
+    ).toEqual([
+      { kind: 'label', name: 'hive' },
+      {
+        kind: 'select',
+        levelIndex: 1,
+        options: ['snap', 'default'],
+        value: '',
+      },
+    ]);
+  });
+
+  it('shows root select when multiple catalogs exist', () => {
+    expect(buildPathHierarchySelectorSegments(supersetTree, {}, [], [])).toEqual([
+      {
+        kind: 'select',
+        levelIndex: 0,
+        options: ['hive', 'pg'],
+        value: '',
+      },
+    ]);
+  });
+});
+
+describe('pathHierarchySelectorSegmentsForUi', () => {
+  it('falls back to catalog/schema placeholders when tree is empty', () => {
+    expect(pathHierarchySelectorSegmentsForUi({}, {}, [], [])).toEqual(
+      PATH_HIERARCHY_PLACEHOLDER_SELECTOR_SEGMENTS,
+    );
   });
 });

--- a/src/lib/connectionLocator.ts
+++ b/src/lib/connectionLocator.ts
@@ -41,6 +41,20 @@ export const RECENT_CONNECTION_LIMIT = 5;
 export const RECENT_GROUP_KEY = '__recent__';
 export const PINNED_GROUP_KEY = '__pinned__';
 
+/** Scoped expand key so the same connection can be expanded independently per navigator section. */
+export function connectionExpandKey(sectionGroup: string, connectionId: string): string {
+  return `${sectionGroup}::${connectionId}`;
+}
+
+export function parseConnectionExpandKey(key: string): {
+  sectionGroup: string;
+  connectionId: string;
+} {
+  const sep = key.indexOf('::');
+  if (sep < 0) return { sectionGroup: '', connectionId: key };
+  return { sectionGroup: key.slice(0, sep), connectionId: key.slice(sep + 2) };
+}
+
 type Candidate = Omit<ConnectionMatch, 'rank'> & { rank: number };
 
 function normalize(value: string | undefined | null): string {

--- a/src/lib/queryContextPath.ts
+++ b/src/lib/queryContextPath.ts
@@ -85,3 +85,122 @@ export function namespaceRootsFrom(
 export function pathsEqual(a: readonly string[], b: readonly string[]): boolean {
   return a.length === b.length && a.every((seg, i) => seg === b[i]);
 }
+
+/** Driver `use_database` pin for path-hierarchy namespaces (e.g. Superset `558/hive/snap`). */
+export function buildPathHierarchyDatabasePin(
+  rootDatabase: string,
+  namespacePath: readonly string[],
+): string {
+  const root = rootDatabase.trim();
+  if (!root) return namespacePath.join('/');
+  if (namespacePath.length === 0) return root;
+  return [root, ...namespacePath].join('/');
+}
+
+/** Inverse of {@link buildPathHierarchyDatabasePin} for table-open / panel bootstrap. */
+export function splitPathHierarchyDatabasePin(pin: string): {
+  root: string;
+  namespacePath: string[];
+} {
+  const trimmed = pin.trim();
+  if (!trimmed) return { root: '', namespacePath: [] };
+  const slash = trimmed.indexOf('/');
+  if (slash < 0) return { root: trimmed, namespacePath: [] };
+  return {
+    root: trimmed.slice(0, slash),
+    namespacePath: trimmed
+      .slice(slash + 1)
+      .split('/')
+      .filter(Boolean),
+  };
+}
+
+export type PathHierarchySelectorSegment =
+  | { kind: 'label'; name: string }
+  | { kind: 'select'; levelIndex: number; options: string[]; value: string };
+
+/**
+ * Extend `contextPath` through single-option namespace levels (auto-pick).
+ * Returns `null` when no change is needed.
+ */
+export function autoCompletePathHierarchyPath(
+  namespaceTree: SqlNamespace,
+  pathAliases: Record<string, string>,
+  databases: readonly string[],
+  contextPath: readonly string[],
+): string[] | null {
+  const roots = namespaceRootsFrom(namespaceTree, pathAliases, databases);
+  if (roots.length === 0) return null;
+
+  let extended = [...contextPath];
+  if (extended.length === 0 && roots.length === 1) {
+    extended = [roots[0]!];
+  }
+
+  while (true) {
+    const children = namespaceBranchChildNames(namespaceTree, extended);
+    if (children.length !== 1) break;
+    extended = [...extended, children[0]!];
+  }
+
+  if (extended.length === contextPath.length && pathsEqual(extended, contextPath)) {
+    return null;
+  }
+  return extended;
+}
+
+/** UI segments: single-option levels become labels; multi-option levels stay as selects. */
+export function buildPathHierarchySelectorSegments(
+  namespaceTree: SqlNamespace,
+  pathAliases: Record<string, string>,
+  databases: readonly string[],
+  contextPath: readonly string[],
+): PathHierarchySelectorSegment[] {
+  const roots = namespaceRootsFrom(namespaceTree, pathAliases, databases);
+  if (roots.length === 0) return [];
+
+  const segments: PathHierarchySelectorSegment[] = [];
+  const path: string[] = [];
+  let options = roots;
+
+  while (options.length > 0) {
+    const depth = path.length;
+    if (options.length === 1) {
+      const only = options[0]!;
+      segments.push({ kind: 'label', name: only });
+      path.push(only);
+    } else {
+      const value = contextPath[depth] ?? '';
+      segments.push({ kind: 'select', levelIndex: depth, options: [...options], value });
+      if (!value) break;
+      path.push(value);
+    }
+
+    const children = namespaceBranchChildNames(namespaceTree, path);
+    if (children.length === 0) break;
+    options = children;
+  }
+
+  return segments;
+}
+
+/** Placeholder UI while namespace tree is loading or has no roots yet. */
+export const PATH_HIERARCHY_PLACEHOLDER_SELECTOR_SEGMENTS: PathHierarchySelectorSegment[] = [
+  { kind: 'select', levelIndex: 0, options: [], value: '' },
+  { kind: 'select', levelIndex: 1, options: [], value: '' },
+];
+
+export function pathHierarchySelectorSegmentsForUi(
+  namespaceTree: SqlNamespace,
+  pathAliases: Record<string, string>,
+  databases: readonly string[],
+  contextPath: readonly string[],
+): PathHierarchySelectorSegment[] {
+  const segments = buildPathHierarchySelectorSegments(
+    namespaceTree,
+    pathAliases,
+    databases,
+    contextPath,
+  );
+  return segments.length > 0 ? segments : PATH_HIERARCHY_PLACEHOLDER_SELECTOR_SEGMENTS;
+}

--- a/src/stores/__tests__/panelStore.test.ts
+++ b/src/stores/__tests__/panelStore.test.ts
@@ -12,12 +12,17 @@ const mockExecuteQueryStream = vi.fn().mockResolvedValue(undefined);
 const mockCancelQuery = vi.fn().mockResolvedValue(undefined);
 
 const activeConnectionState: {
-  connections: Record<string, { capabilities?: {
-    supportsCancelQuery: boolean;
-    supportsQueryExecutionCancel: boolean;
-    supportsExplain: boolean;
-    supportsStreamingResults: boolean;
-  } }>;
+  connections: Record<
+    string,
+    {
+      capabilities?: {
+        supportsCancelQuery: boolean;
+        supportsQueryExecutionCancel: boolean;
+        supportsExplain: boolean;
+        supportsStreamingResults: boolean;
+      };
+    }
+  >;
 } = {
   connections: {
     'cfg-1': {
@@ -150,6 +155,80 @@ describe('panelStore', () => {
       'SELECT * FROM users',
       expect.any(Function),
       { database: 'db_b', schema: 'sales' },
+    );
+  });
+
+  it('executeQuery forwards path-hierarchy catalog/schema pin for Superset', async () => {
+    seedCurrentDatabase('sess-1', '558:presto_afi_data');
+    useSchemaStore.setState((state) => {
+      const schemas = new Map(state.schemas);
+      const entry = schemas.get('sess-1');
+      if (!entry) return state;
+      schemas.set('sess-1', {
+        ...entry,
+        namespaceTree: { hive: { snap: { orders: 'table' } } },
+        pathAliases: { hive: '558' },
+        databases: ['558:presto_afi_data'],
+      });
+      return { ...state, schemas };
+    });
+    const panel: Panel = {
+      ...base,
+      databaseType: 'superset',
+      type: 'query',
+      id: nextPanelId('qry'),
+      title: 'Q1',
+      namespacePath: ['hive', 'snap'],
+    };
+    usePanelStore.getState().addPanel(panel);
+    usePanelStore
+      .getState()
+      .updateSql(panel.id, 'SELECT * FROM afi_id_loan_t_afi_installment_order');
+
+    await usePanelStore.getState().executeQuery(panel.id);
+
+    expect(mockExecuteQueryStream).toHaveBeenCalledWith(
+      'sess-1',
+      'SELECT * FROM afi_id_loan_t_afi_installment_order',
+      expect.any(Function),
+      { database: '558:presto_afi_data/hive/snap', schema: null },
+    );
+  });
+
+  it('executeQuery infers path-hierarchy pin from qualified SQL', async () => {
+    seedCurrentDatabase('sess-1', '558:presto_afi_data');
+    useSchemaStore.setState((state) => {
+      const schemas = new Map(state.schemas);
+      const entry = schemas.get('sess-1');
+      if (!entry) return state;
+      schemas.set('sess-1', {
+        ...entry,
+        namespaceTree: { hive: { snap: {} } },
+        pathAliases: { hive: '558' },
+        databases: ['558:presto_afi_data'],
+      });
+      return { ...state, schemas };
+    });
+    const panel: Panel = {
+      ...base,
+      databaseType: 'superset',
+      type: 'query',
+      id: nextPanelId('qry'),
+      title: 'Q1',
+      namespacePath: ['hive'],
+    };
+    usePanelStore.getState().addPanel(panel);
+    usePanelStore
+      .getState()
+      .updateSql(panel.id, 'SELECT * FROM hive.snap.afi_id_loan_t_afi_installment_order');
+
+    await usePanelStore.getState().executeQuery(panel.id);
+
+    expect(mockExecuteQueryStream).toHaveBeenCalledWith(
+      'sess-1',
+      'SELECT * FROM hive.snap.afi_id_loan_t_afi_installment_order',
+      expect.any(Function),
+      { database: '558:presto_afi_data/hive/snap', schema: null },
     );
   });
 

--- a/src/stores/panelStore.ts
+++ b/src/stores/panelStore.ts
@@ -1,6 +1,13 @@
 import { create } from 'zustand';
 import { queryCommands } from '../commands/query';
 import { t } from '../locales/t';
+import { DB_REGISTRY } from '../lib/databaseTypes';
+import {
+  buildPathHierarchyDatabasePin,
+  inferSqlRelationPath,
+  namespaceRootsFrom,
+  resolveQueryContextPath,
+} from '../lib/queryContextPath';
 import type { DatabaseType, FavoriteQuery, QueryHistoryEntry, Value } from '../types';
 import type { ChartConfig } from '../types/chart';
 import type { TrendSeries } from '../lib/serverStatusTrends';
@@ -58,9 +65,11 @@ export interface ViewPanel extends PanelBase {
 export interface QueryPanel extends PanelBase {
   type: 'query';
   title: string;
-  /** Target namespace captured when a table action opens this query. */
+  /** Superset / path-hierarchy connection database (not catalog name). */
   database?: string;
   schema?: string;
+  /** Catalog/schema segments for path-hierarchy query context selectors. */
+  namespacePath?: string[];
 }
 
 export interface CreateTablePanel extends PanelBase {
@@ -165,11 +174,7 @@ function cancelAndCleanupExec(
       const exec = nextExec.get(panel.id);
       const capabilities =
         useActiveConnectionStore.getState().connections[panel.connectionId]?.capabilities;
-      if (
-        exec?.running &&
-        exec.executionId &&
-        getCancelCapability(capabilities) === 'supported'
-      ) {
+      if (exec?.running && exec.executionId && getCancelCapability(capabilities) === 'supported') {
         queryCommands.cancelQuery(panel.dbSessionId, exec.executionId).catch(() => {});
       }
       nextExec.delete(panel.id);
@@ -247,9 +252,38 @@ interface PanelActions {
  * selected database explicitly — the backend pins the session to it before
  * running unqualified SQL (BUG-001 fix).
  */
-function panelTargetDatabase(panel: QueryPanel): string | null {
+function panelTargetDatabase(panel: QueryPanel, sql?: string): string | null {
+  const schemaState = useSchemaStore.getState().schemas.get(panel.dbSessionId);
+  const meta = DB_REGISTRY[panel.databaseType];
+  if (meta?.namespaceEnsure === 'path-hierarchy') {
+    const databases = schemaState?.databases ?? [];
+    const pathAliases = schemaState?.pathAliases ?? {};
+    const namespaceTree = schemaState?.namespaceTree ?? {};
+    const roots = namespaceRootsFrom(namespaceTree, pathAliases, databases);
+    const rootSet = new Set(roots);
+    let fromSql = sql?.trim()
+      ? resolveQueryContextPath(sql, { databases, namespaceRoots: roots })
+      : null;
+    if (sql?.trim()) {
+      const relation = inferSqlRelationPath(sql);
+      if (relation.length >= 3) {
+        const inferred = relation.slice(0, -1);
+        if (!fromSql || inferred.length > fromSql.length) fromSql = inferred;
+      } else if (relation.length >= 2) {
+        const inferred = relation.slice(0, -1);
+        if (inferred[0] && rootSet.has(inferred[0])) {
+          if (!fromSql || inferred.length > fromSql.length) fromSql = inferred;
+        }
+      }
+    }
+    const namespacePath = fromSql ?? panel.namespacePath ?? [];
+    const root = (panel.database?.trim() || schemaState?.currentDatabase) ?? null;
+    if (!root && namespacePath.length === 0) return null;
+    if (!root) return namespacePath.join('/');
+    return buildPathHierarchyDatabasePin(root, namespacePath);
+  }
   if (panel.database?.trim()) return panel.database;
-  return useSchemaStore.getState().schemas.get(panel.dbSessionId)?.currentDatabase ?? null;
+  return schemaState?.currentDatabase ?? null;
 }
 
 /**
@@ -396,7 +430,7 @@ export const usePanelStore = create<PanelState & PanelActions>((set, get) => ({
         params,
         getExec,
         setExec,
-        panelTargetDatabase(panel),
+        panelTargetDatabase(panel, sql),
         panelTargetSchema(panel),
       );
     } else {
@@ -406,7 +440,7 @@ export const usePanelStore = create<PanelState & PanelActions>((set, get) => ({
         sql,
         getExec,
         setExec,
-        panelTargetDatabase(panel),
+        panelTargetDatabase(panel, sql),
         panelTargetSchema(panel),
       );
     }
@@ -429,7 +463,7 @@ export const usePanelStore = create<PanelState & PanelActions>((set, get) => ({
         params,
         getExec,
         setExec,
-        panelTargetDatabase(panel),
+        panelTargetDatabase(panel, sql),
         panelTargetSchema(panel),
       );
     } else {
@@ -439,7 +473,7 @@ export const usePanelStore = create<PanelState & PanelActions>((set, get) => ({
         sql,
         getExec,
         setExec,
-        panelTargetDatabase(panel),
+        panelTargetDatabase(panel, sql),
         panelTargetSchema(panel),
       );
     }

--- a/src/windows/connection/ConnectionNavigatorTree.tsx
+++ b/src/windows/connection/ConnectionNavigatorTree.tsx
@@ -16,6 +16,12 @@ import {
   groupConnectionsWithPinnedSection,
   useConnectionStore,
 } from '../../stores/connectionStore';
+import {
+  connectionExpandKey,
+  parseConnectionExpandKey,
+  PINNED_GROUP_KEY,
+  RECENT_GROUP_KEY,
+} from '../../lib/connectionLocator';
 import { useActiveConnectionStore } from '../../stores/activeConnectionStore';
 import { useSchemaStore } from '../../stores/schemaStore';
 import { useSettingsStore } from '../../stores/settingsStore';
@@ -181,14 +187,18 @@ export const ConnectionNavigatorTree = forwardRef<
       let changed = false;
       const next = new Set(prev);
       for (const [connectionId, entry] of Object.entries(activeConnections)) {
-        if (entry?.status === 'connected' && !next.has(connectionId)) {
-          next.add(connectionId);
+        if (entry?.status !== 'connected') continue;
+        const conn = connections.find((c) => c.id === connectionId);
+        const sectionKey = conn?.pinned ? PINNED_GROUP_KEY : RECENT_GROUP_KEY;
+        const key = connectionExpandKey(sectionKey, connectionId);
+        if (!next.has(key)) {
+          next.add(key);
           changed = true;
         }
       }
       return changed ? next : prev;
     });
-  }, [activeConnections]);
+  }, [activeConnections, connections]);
 
   const loadedConnectionsRef = useRef<Set<string>>(new Set());
   const prevConnectionIdsRef = useRef<Set<string>>(new Set());
@@ -206,7 +216,8 @@ export const ConnectionNavigatorTree = forwardRef<
   }, [activeConnections]);
 
   useEffect(() => {
-    for (const connectionId of expandedConnections) {
+    for (const key of expandedConnections) {
+      const { connectionId } = parseConnectionExpandKey(key);
       const entry = activeConnections[connectionId];
       if (entry?.status !== 'connected' || !entry.dbSessionId) continue;
       if (loadedConnectionsRef.current.has(connectionId)) continue;
@@ -279,13 +290,14 @@ export const ConnectionNavigatorTree = forwardRef<
   }, []);
 
   const toggleConnection = useCallback(
-    (connectionId: string) => {
+    (connectionId: string, sectionGroup: string) => {
+      const key = connectionExpandKey(sectionGroup, connectionId);
       setExpandedConnections((prev) => {
         const next = new Set(prev);
-        if (next.has(connectionId)) {
-          next.delete(connectionId);
+        if (next.has(key)) {
+          next.delete(key);
         } else {
-          next.add(connectionId);
+          next.add(key);
           onSelectConnection(connectionId);
         }
         return next;
@@ -462,13 +474,14 @@ export const ConnectionNavigatorTree = forwardRef<
   );
 
   const handleConnectionClick = useCallback(
-    (conn: ConnectionConfig) => {
+    (conn: ConnectionConfig, sectionGroup: string) => {
       onSelectConnection(conn.id);
       const entry = activeConnections[conn.id];
       if (entry?.status === 'connected') {
+        const key = connectionExpandKey(sectionGroup, conn.id);
         setExpandedConnections((prev) => {
-          if (prev.has(conn.id)) return prev;
-          return new Set(prev).add(conn.id);
+          if (prev.has(key)) return prev;
+          return new Set(prev).add(key);
         });
       }
     },

--- a/src/windows/connection/PanelContentRenderer.tsx
+++ b/src/windows/connection/PanelContentRenderer.tsx
@@ -269,6 +269,7 @@ function SqlPanelContent({
         databaseType={panel.databaseType}
         database={panel.database}
         schema={panel.schema}
+        namespacePath={panel.namespacePath}
       />
     );
   }

--- a/src/windows/connection/QueryPanel.tsx
+++ b/src/windows/connection/QueryPanel.tsx
@@ -45,6 +45,7 @@ import {
   namespaceRootsFrom,
   pathsEqual,
   resolveQueryContextPath,
+  autoCompletePathHierarchyPath,
 } from '../../lib/queryContextPath';
 import { QueryContextSelectors } from '../../components/query/QueryContextSelectors';
 import { QueryErrorPanel } from '../../components/query/QueryErrorPanel';
@@ -101,6 +102,7 @@ interface QueryPanelProps {
   connectionName?: string;
   database?: string;
   schema?: string;
+  namespacePath?: string[];
 }
 
 function hasSuspiciousPostgresDoubleQuotedLiteral(sql: string): boolean {
@@ -233,6 +235,7 @@ export function QueryPanel({
   connectionName,
   database,
   schema,
+  namespacePath: panelNamespacePath,
 }: QueryPanelProps) {
   const { t } = useI18n();
   const [confirmRetry, confirmRetryDialog] = useConfirmDialog();
@@ -325,7 +328,11 @@ export function QueryPanel({
   const switchDatabase = useSchemaStore((s) => s.switchDatabase);
   const ensureNamespacePath = useSchemaStore((s) => s.ensureNamespacePath);
   const namespaceLoading = useSchemaStore((s) => s.ensuringCount > 0);
-  const selectedDatabase = database ?? currentDatabase;
+  const dbMeta = databaseType ? DB_REGISTRY[databaseType as keyof typeof DB_REGISTRY] : undefined;
+  const isPathHierarchyDriver = dbMeta?.namespaceEnsure === 'path-hierarchy';
+  const selectedDatabase = isPathHierarchyDriver
+    ? (currentDatabase ?? database)
+    : (database ?? currentDatabase);
   const selectedSchema = schema ?? currentSchema;
   const currentDiagnosisSchemaState = useMemo(
     () => ({ currentDatabase, currentSchema, tables, views, columnMap }),
@@ -341,13 +348,10 @@ export function QueryPanel({
     return () => window.clearTimeout(timer);
   }, [exec.running]);
 
-  const dbMeta = databaseType ? DB_REGISTRY[databaseType as keyof typeof DB_REGISTRY] : undefined;
   const supportsExplain = dbMeta?.supportsExplain === true;
-  const isPathHierarchy = dbMeta?.namespaceEnsure === 'path-hierarchy';
-  const hasContextSelectors =
-    (isPathHierarchy && namespaceRootsFrom(namespaceTree, pathAliases, databases).length > 0) ||
-    (isMultiDb && databases.length > 0);
-  const [contextPath, setContextPath] = useState<string[]>([]);
+  const isPathHierarchy = isPathHierarchyDriver;
+  const hasContextSelectors = isPathHierarchy || (isMultiDb && databases.length > 0);
+  const [contextPath, setContextPath] = useState<string[]>(() => panelNamespacePath ?? []);
   const queryToolbarExpandedMinWidthValue = useMemo(
     () =>
       queryToolbarExpandedMinWidth({
@@ -414,6 +418,7 @@ export function QueryPanel({
     async (next: string[]) => {
       setContextPath(next);
       if (isPathHierarchy) {
+        updatePanel(panelId, { namespacePath: next.length > 0 ? next : undefined });
         if (next.length > 0) await ensureNamespacePath(next);
         return;
       }
@@ -428,14 +433,24 @@ export function QueryPanel({
         await switchDatabase(db);
       }
     },
-    [currentDatabase, ensureNamespacePath, isPathHierarchy, switchDatabase],
+    [currentDatabase, ensureNamespacePath, isPathHierarchy, panelId, switchDatabase, updatePanel],
   );
+
+  useEffect(() => {
+    if (!isPathHierarchy) return;
+    const next = autoCompletePathHierarchyPath(namespaceTree, pathAliases, databases, contextPath);
+    if (next) {
+      void applyContextPath(next);
+    }
+  }, [isPathHierarchy, namespaceTree, pathAliases, databases, contextPath, applyContextPath]);
 
   const handleSelectContextLevel = useCallback(
     (index: number, value: string) => {
       if (!value) return;
-      if (index === 0) updatePanel(panelId, { database: value });
-      if (index === 1) updatePanel(panelId, { schema: value });
+      if (!isPathHierarchy) {
+        if (index === 0) updatePanel(panelId, { database: value });
+        if (index === 1) updatePanel(panelId, { schema: value });
+      }
       void applyContextPath([...contextPath.slice(0, index), value]);
     },
     [applyContextPath, contextPath, panelId, updatePanel],

--- a/src/windows/connection/__tests__/queryToolbarWidth.test.ts
+++ b/src/windows/connection/__tests__/queryToolbarWidth.test.ts
@@ -17,27 +17,27 @@ describe('queryToolbarExpandedMinWidth', () => {
     expect(width).toBe(32 + 9 * 84 + 8 * 8 + 8);
   });
 
-  it('adds path-hierarchy selector width by level count', () => {
-    const withOneLevel = queryToolbarExpandedMinWidth({
+  it('reserves path-hierarchy selector width before namespace loads', () => {
+    const withoutTree = queryToolbarExpandedMinWidth({
       supportsExplain: false,
       hasContextSelectors: true,
       isPathHierarchy: true,
       isMultiDb: false,
-      namespaceTree: { hive: {} },
-      pathAliases: { hive: '558' },
+      namespaceTree: {},
+      pathAliases: {},
       databases: [],
       contextPath: [],
     });
-    const withTwoLevels = queryToolbarExpandedMinWidth({
+    const withoutSelectors = queryToolbarExpandedMinWidth({
       supportsExplain: false,
-      hasContextSelectors: true,
-      isPathHierarchy: true,
+      hasContextSelectors: false,
+      isPathHierarchy: false,
       isMultiDb: false,
-      namespaceTree: { hive: { snap: {} } },
-      pathAliases: { hive: '558' },
+      namespaceTree: {},
+      pathAliases: {},
       databases: [],
-      contextPath: ['hive'],
+      contextPath: [],
     });
-    expect(withTwoLevels).toBeGreaterThan(withOneLevel);
+    expect(withoutTree).toBeGreaterThan(withoutSelectors);
   });
 });

--- a/src/windows/connection/navigator/NavigatorTreeRow.tsx
+++ b/src/windows/connection/navigator/NavigatorTreeRow.tsx
@@ -33,7 +33,7 @@ export interface NavigatorTreeRowProps {
   onSelectTable: (tableName: string, schema?: string, database?: string) => void;
   onSelectKvDb?: (connectionId: string, dbName: string) => void;
   toggleGroup: (group: string) => void;
-  toggleConnection: (connectionId: string) => void;
+  toggleConnection: (connectionId: string, sectionGroup: string) => void;
   toggleDb: (connectionId: string, dbSessionId: string, dbName: string) => void;
   toggleSchema: (schemaKey: string) => void;
   toggleCategory: (catKey: string, catId: string, dbSessionId: string) => void;
@@ -41,7 +41,11 @@ export interface NavigatorTreeRowProps {
   ensureNamespacePath: (segments: string[], dbSessionId: string) => Promise<void>;
   setExpandedDbs: React.Dispatch<React.SetStateAction<Set<string>>>;
   handleGroupContextMenu: (e: React.MouseEvent, groupName: string) => void;
-  handleConnectionContextMenu: (e: React.MouseEvent, conn: ConnectionConfig) => void;
+  handleConnectionContextMenu: (
+    e: React.MouseEvent,
+    conn: ConnectionConfig,
+    sectionGroup: string,
+  ) => void;
   handleDatabaseContextMenu: (e: React.MouseEvent, dbName: string, connectionId: string) => void;
   handleSchemaContextMenu: (
     e: React.MouseEvent,
@@ -67,7 +71,7 @@ export interface NavigatorTreeRowProps {
     connectionId: string,
   ) => void;
   handleObjectContextMenu: (e: React.MouseEvent, name: string) => void;
-  handleConnectionClick: (conn: ConnectionConfig) => void;
+  handleConnectionClick: (conn: ConnectionConfig, sectionGroup: string) => void;
   handleConnectionDoubleClick: (conn: ConnectionConfig) => void;
   handleDragStart: (e: React.DragEvent, connId: string) => void;
   handleDragOver: (e: React.DragEvent, targetId: string) => void;
@@ -185,9 +189,9 @@ export function NavigatorTreeRow({
                 : 'text-fg-secondary hover:bg-surface-raised hover:text-fg',
             )}
             style={{ paddingLeft: depthPadding(row.depth) }}
-            onClick={() => handleConnectionClick(row.conn)}
+            onClick={() => handleConnectionClick(row.conn, row.sectionGroup)}
             onDoubleClick={() => handleConnectionDoubleClick(row.conn)}
-            onContextMenu={(e) => handleConnectionContextMenu(e, row.conn)}
+            onContextMenu={(e) => handleConnectionContextMenu(e, row.conn, row.sectionGroup)}
           >
             {row.isSelected && <span className="absolute inset-y-0 left-0 w-0.5 bg-accent" />}
             <button
@@ -196,7 +200,7 @@ export function NavigatorTreeRow({
               onClick={(e) => {
                 e.stopPropagation();
                 if (row.status === 'connected') {
-                  toggleConnection(row.conn.id);
+                  toggleConnection(row.conn.id, row.sectionGroup);
                 } else {
                   handleConnectionDoubleClick(row.conn);
                 }

--- a/src/windows/connection/navigator/buildFlatRows.ts
+++ b/src/windows/connection/navigator/buildFlatRows.ts
@@ -12,6 +12,7 @@ import {
   rankConnections,
   PINNED_GROUP_KEY,
   RECENT_GROUP_KEY,
+  connectionExpandKey,
   type ConnectionLocatorUsageState,
 } from '../../../lib/connectionLocator';
 import type { ConnectionEntry } from '../../../stores/activeConnectionStore';
@@ -208,11 +209,13 @@ export function buildNavigatorFlatRows(params: BuildNavigatorFlatRowsParams): Un
       const entry = activeConnections[conn.id];
       const status = entry?.status ?? 'idle';
       const isConnected = status === 'connected';
-      const isExpanded = expandedConnections.has(conn.id) || !!query;
+      const isExpanded =
+        expandedConnections.has(connectionExpandKey(groupName, conn.id)) || !!query;
 
       rows.push({
         type: 'connection',
         conn,
+        sectionGroup: groupName,
         isSelected: activeConnectionId === conn.id,
         status,
         expanded: (isExpanded && isConnected) || !!query,

--- a/src/windows/connection/navigator/types.ts
+++ b/src/windows/connection/navigator/types.ts
@@ -15,6 +15,7 @@ export type UnifiedRow =
   | {
       type: 'connection';
       conn: ConnectionConfig;
+      sectionGroup: string;
       isSelected: boolean;
       status: string;
       expanded: boolean;
@@ -115,7 +116,10 @@ export interface ConnectionNavigatorTreeProps {
     schema?: string;
   }) => void;
   viewActions?: {
-    newQuery?: (initialSql?: string, context?: Pick<TableContextInput, 'database' | 'schema'>) => void;
+    newQuery?: (
+      initialSql?: string,
+      context?: Pick<TableContextInput, 'database' | 'schema'>,
+    ) => void;
     openTableAction?: (context: TableContextInput, action: TableSqlActionKind) => void;
     openSqlFile?: () => void;
     createTable?: () => void;

--- a/src/windows/connection/navigator/useNavigatorContextMenus.ts
+++ b/src/windows/connection/navigator/useNavigatorContextMenus.ts
@@ -61,7 +61,7 @@ export interface NavigatorContextMenuDeps {
   deleteGroup: (name: string) => Promise<void>;
   moveConnectionToGroup: (id: string, group?: string) => Promise<void>;
   toggleConnectionPinned: (id: string) => Promise<void>;
-  toggleConnection: (connectionId: string) => void;
+  toggleConnection: (connectionId: string, sectionGroup: string) => void;
   refreshConnection: (connectionId: string) => Promise<void>;
   refreshDatabase: (connectionId: string, dbName: string) => Promise<void>;
   refreshSchema: (connectionId: string, dbName: string, schemaName: string) => Promise<void>;
@@ -250,7 +250,7 @@ export function useNavigatorContextMenus(deps: NavigatorContextMenuDeps) {
   );
 
   const handleConnectionContextMenu = useCallback(
-    (e: React.MouseEvent, conn: ConnectionConfig) => {
+    (e: React.MouseEvent, conn: ConnectionConfig, sectionGroup: string) => {
       e.preventDefault();
       e.stopPropagation();
 
@@ -282,7 +282,7 @@ export function useNavigatorContextMenus(deps: NavigatorContextMenuDeps) {
                 onDisconnect(conn.id);
               } else {
                 onSelectConnection(conn.id);
-                toggleConnection(conn.id);
+                toggleConnection(conn.id, sectionGroup);
                 void connect(conn);
               }
             },

--- a/src/windows/connection/queryToolbarWidth.ts
+++ b/src/windows/connection/queryToolbarWidth.ts
@@ -1,9 +1,34 @@
 import { TOOLBAR_GAP, TOOLBAR_HORIZONTAL_PADDING } from '../../hooks/useCompactToolbar';
-import { namespaceRootsFrom } from '../../lib/queryContextPath';
+import { pathHierarchySelectorSegmentsForUi } from '../../lib/queryContextPath';
 import type { SqlNamespace } from '../../lib/sqlNamespace';
 
 /** Slightly under measured width so expanded labels show when space is adequate. */
 const QUERY_TOOLBAR_BUTTON_WIDTH = 84;
+const PATH_HIERARCHY_SELECT_MAX = 88;
+const PATH_HIERARCHY_SELECT_MIN = 40;
+const PATH_HIERARCHY_LABEL_MAX = 72;
+const PATH_HIERARCHY_CHAR_PX = 6.5;
+const PATH_HIERARCHY_SELECT_CHROME = 28;
+const PATH_HIERARCHY_SEGMENT_GAP = 8;
+const PATH_HIERARCHY_PLACEHOLDER_CHARS = 6;
+
+function pathHierarchySelectWidth(value: string): number {
+  const len = value.length > 0 ? value.length : PATH_HIERARCHY_PLACEHOLDER_CHARS;
+  return Math.min(
+    PATH_HIERARCHY_SELECT_MAX,
+    Math.max(
+      PATH_HIERARCHY_SELECT_MIN,
+      Math.ceil(len * PATH_HIERARCHY_CHAR_PX + PATH_HIERARCHY_SELECT_CHROME),
+    ),
+  );
+}
+
+function pathHierarchyLabelWidth(name: string): number {
+  return Math.min(
+    PATH_HIERARCHY_LABEL_MAX,
+    Math.max(24, Math.ceil(name.length * PATH_HIERARCHY_CHAR_PX)),
+  );
+}
 
 export function queryToolbarExpandedMinWidth(options: {
   supportsExplain: boolean;
@@ -21,15 +46,22 @@ export function queryToolbarExpandedMinWidth(options: {
   let contextWidth = 0;
   if (options.hasContextSelectors) {
     if (options.isPathHierarchy) {
-      const roots = namespaceRootsFrom(
+      const segments = pathHierarchySelectorSegmentsForUi(
         options.namespaceTree,
         options.pathAliases,
         options.databases,
+        options.contextPath,
       );
-      if (roots.length > 0) {
-        const levelCount = Math.max(1, Math.min(4, 1 + options.contextPath.length));
-        contextWidth = 20 + levelCount * 112 + Math.max(0, levelCount - 1) * 6;
-      }
+      const segmentWidth = segments.reduce((sum, segment) => {
+        if (segment.kind === 'label') {
+          return sum + pathHierarchyLabelWidth(segment.name);
+        }
+        return sum + pathHierarchySelectWidth(segment.value);
+      }, 0);
+      contextWidth =
+        20 +
+        Math.max(segmentWidth, PATH_HIERARCHY_SELECT_MIN * 2) +
+        Math.max(0, segments.length - 1) * PATH_HIERARCHY_SEGMENT_GAP;
     } else if (options.isMultiDb) {
       contextWidth = 196;
     } else if (options.contextSchema) {

--- a/src/windows/connection/usePanelHandlers.ts
+++ b/src/windows/connection/usePanelHandlers.ts
@@ -19,7 +19,13 @@ import {
 } from '../../stores/panelStore';
 import { showNativeContextMenu } from '../../lib/nativeContextMenu';
 import { buildConnectionTabContextMenuItems } from '../../lib/connectionTabContextMenu';
-import { buildQueryOpenContext, type TableContextInput, type TableSqlActionKind } from '../../lib/tableSqlActions';
+import {
+  buildQueryOpenContext,
+  type TableContextInput,
+  type TableSqlActionKind,
+} from '../../lib/tableSqlActions';
+import { DB_REGISTRY } from '../../lib/databaseTypes';
+import { splitPathHierarchyDatabasePin } from '../../lib/queryContextPath';
 
 export interface PanelHandlers {
   handleSelectTable: (table: string, schema?: string, database?: string) => void;
@@ -371,14 +377,23 @@ export function usePanelHandlers({
     (initialSql?: string, target?: Pick<TableContextInput, 'database' | 'schema'>) => {
       if (!sidebarConnCtx) return;
       const panelId = nextPanelId('qry');
-      const db = target?.database ?? currentDatabase ?? initialDatabase ?? '';
+      let panelDatabase = target?.database?.trim() || undefined;
+      let namespacePath: string[] | undefined;
+      const meta = DB_REGISTRY[sidebarConnCtx.databaseType];
+      if (meta?.namespaceEnsure === 'path-hierarchy' && panelDatabase?.includes('/')) {
+        const split = splitPathHierarchyDatabasePin(panelDatabase);
+        panelDatabase = split.root || undefined;
+        namespacePath = split.namespacePath.length > 0 ? split.namespacePath : undefined;
+      }
+      const db = panelDatabase ?? currentDatabase ?? initialDatabase ?? '';
       const panel: QueryPanel = {
         ...sidebarConnCtx,
         type: 'query',
         id: panelId,
         title: db ? `${sidebarConnCtx.connectionName}@${db}` : sidebarConnCtx.connectionName,
-        database: target?.database?.trim() || undefined,
+        database: panelDatabase || undefined,
         schema: target?.schema?.trim() || undefined,
+        namespacePath,
       };
       addPanel(panel);
       if (initialSql) updateSql(panelId, initialSql);


### PR DESCRIPTION
## Summary

- Fix Superset/path-hierarchy queries defaulting to wrong schema (`hive.default.*`) by pinning catalog/schema into `panelTargetDatabase` and syncing `namespacePath` on the query panel.
- Auto-complete single-option path-hierarchy levels, show static labels for fixed segments, and reserve toolbar space with placeholder Catalog/Schema selects while namespace loads.
- Add searchable combobox `Select` with `fitContent` width (max 5.5rem) for query context selectors.
- Isolate connection tree expand/collapse per navigator section (e.g. Recent vs original group).

## Test plan

- [x] `npx vitest run src/lib/__tests__/queryContextPath.test.ts src/lib/__tests__/connectionLocator.test.ts src/stores/__tests__/panelStore.test.ts src/windows/connection/__tests__/queryToolbarWidth.test.ts src/components/ui/__tests__/Select.test.tsx`
- [ ] Superset: open query panel → Catalog/Schema selectors visible immediately; pick `hive` / `snap` → unqualified SQL resolves under `hive.snap`
- [ ] Connection tree: expand connection in Recent without expanding the same connection in its saved group
- [ ] Path-hierarchy Select: type to filter options; width grows with value up to 5.5rem


Made with [Cursor](https://cursor.com)