### PR TITLE
fix(navigator): keep connection expansion scoped and exclusive

### DIFF
--- a/e2e/specs/connection-navigator-expansion.ts
+++ b/e2e/specs/connection-navigator-expansion.ts
@@ -1,0 +1,236 @@
+import { expect, browser, $ } from '@wdio/globals';
+import { expandAllGroups } from '../helpers.js';
+import { t } from '../i18n.js';
+
+const GROUP_A = 'E2E-Navigator-Group-A';
+const GROUP_B = 'E2E-Navigator-Group-B';
+const RECENT_ID = 'e2e-navigator-recent';
+const OTHER_ID = 'e2e-navigator-other';
+const RECENT_NAME = 'E2E Navigator Recent';
+const OTHER_NAME = 'E2E Navigator Other';
+
+type ConnectionConfig = {
+  id: string;
+  name: string;
+  databaseType: 'postgresql';
+  host: string;
+  port: number;
+  database: string;
+  username: string;
+  password: string;
+  group: string;
+  sslMode: 'disable';
+  lastConnectedAt?: string;
+};
+
+async function invokeBackend<T>(cmd: string, args: Record<string, unknown> = {}): Promise<T> {
+  const result = await browser.executeAsync(
+    (command: string, serializedArgs: string, done: (value: unknown) => void) => {
+      (window as any).__TAURI_INTERNALS__
+        .invoke(command, JSON.parse(serializedArgs))
+        .then((value: unknown) => done(value))
+        .catch((error: unknown) => done({ __error: String(error) }));
+    },
+    cmd,
+    JSON.stringify(args),
+  );
+  if (result && typeof result === 'object' && '__error' in (result as Record<string, unknown>)) {
+    throw new Error(String((result as Record<string, unknown>).__error));
+  }
+  return result as T;
+}
+
+function connectionConfig(
+  id: string,
+  name: string,
+  group: string,
+  lastConnectedAt?: string,
+): ConnectionConfig {
+  return {
+    id,
+    name,
+    databaseType: 'postgresql',
+    host: process.env.E2E_PG_HOST || '127.0.0.1',
+    port: Number(process.env.E2E_PG_PORT) || 5432,
+    database: process.env.E2E_PG_DB || 'postgres',
+    username: process.env.E2E_PG_USER || 'postgres',
+    password: process.env.E2E_PG_PASSWORD || '',
+    group,
+    sslMode: 'disable',
+    ...(lastConnectedAt ? { lastConnectedAt } : {}),
+  };
+}
+
+async function dispatchRowAction(
+  group: string,
+  name: string,
+  action: 'click' | 'doubleClick',
+): Promise<boolean> {
+  return browser.execute(
+    (sectionGroup: string, connName: string, eventName: string) => {
+      const row = Array.from(document.querySelectorAll<HTMLElement>('[data-conn-item]')).find(
+        (item) => item.dataset.connGroup === sectionGroup && item.dataset.connName === connName,
+      );
+      if (!row) return false;
+      if (eventName === 'click') {
+        row.querySelector<HTMLElement>('button')?.click();
+      } else {
+        row.dispatchEvent(new MouseEvent('dblclick', { bubbles: true, cancelable: true }));
+      }
+      return true;
+    },
+    group,
+    name,
+    action,
+  );
+}
+
+async function waitForRow(group: string, name: string): Promise<void> {
+  await browser.waitUntil(
+    async () =>
+      browser.execute(
+        (sectionGroup: string, connName: string) =>
+          Boolean(
+            Array.from(document.querySelectorAll<HTMLElement>('[data-conn-item]')).find(
+              (item) =>
+                item.dataset.connGroup === sectionGroup && item.dataset.connName === connName,
+            ),
+          ),
+        group,
+        name,
+      ),
+    { timeout: 10000, timeoutMsg: `等待连接行 ${group}/${name} 超时` },
+  );
+}
+
+async function getExpanded(group: string, name: string): Promise<string | null> {
+  return browser.execute(
+    (sectionGroup: string, connName: string) => {
+      const row = Array.from(document.querySelectorAll<HTMLElement>('[data-conn-item]')).find(
+        (item) => item.dataset.connGroup === sectionGroup && item.dataset.connName === connName,
+      );
+      return row?.querySelector('button')?.getAttribute('aria-expanded') ?? null;
+    },
+    group,
+    name,
+  );
+}
+
+async function waitForConnected(group: string, name: string): Promise<void> {
+  const connectedTitle = t('conn.connected');
+  await browser.waitUntil(
+    async () => {
+      const status = await browser.execute(
+        (sectionGroup: string, connName: string, title: string) => {
+          const row = Array.from(document.querySelectorAll<HTMLElement>('[data-conn-item]')).find(
+            (item) => item.dataset.connGroup === sectionGroup && item.dataset.connName === connName,
+          );
+          return row?.querySelector(`[title="${title}"]`) != null;
+        },
+        group,
+        name,
+        connectedTitle,
+      );
+      return status;
+    },
+    { timeout: 30000, timeoutMsg: `等待连接 ${name} 建立连接超时` },
+  );
+}
+
+describe('连接导航树单连接展开 (NAV-EXPAND)', () => {
+  let mainWindow: string;
+
+  before(async () => {
+    mainWindow = await browser.getWindowHandle();
+
+    const existingGroups = await invokeBackend<string[]>('get_groups');
+    await invokeBackend('save_groups', {
+      groups: [
+        ...existingGroups.filter((group) => group !== GROUP_A && group !== GROUP_B),
+        GROUP_A,
+        GROUP_B,
+      ],
+    });
+    for (const id of [RECENT_ID, OTHER_ID]) {
+      try {
+        await invokeBackend('delete_connection', { id });
+      } catch {
+        /* best effort */
+      }
+    }
+
+    await invokeBackend('save_connection', {
+      config: connectionConfig(RECENT_ID, RECENT_NAME, GROUP_A, new Date().toISOString()),
+    });
+    await invokeBackend('save_connection', {
+      config: connectionConfig(OTHER_ID, OTHER_NAME, GROUP_B),
+    });
+
+    await browser.execute(() => location.reload());
+    await $(`input[placeholder="${t('main.searchPlaceholder')}"]`).waitForDisplayed({
+      timeout: 10000,
+    });
+    await expandAllGroups();
+    await waitForRow('__recent__', RECENT_NAME);
+    await waitForRow(GROUP_A, RECENT_NAME);
+    await waitForRow(GROUP_B, OTHER_NAME);
+  });
+
+  after(async () => {
+    await browser.switchToWindow(mainWindow);
+    for (const id of [RECENT_ID, OTHER_ID]) {
+      try {
+        await invokeBackend('delete_connection', { id });
+      } catch {
+        /* best effort */
+      }
+    }
+    try {
+      const groups = await invokeBackend<string[]>('get_groups');
+      await invokeBackend('save_groups', {
+        groups: groups.filter((group) => group !== GROUP_A && group !== GROUP_B),
+      });
+    } catch {
+      /* best effort */
+    }
+    await browser.execute(() => location.reload());
+    await browser.pause(800);
+  });
+
+  it('第一次打开最近连接时不会展开其他分组的连接', async () => {
+    expect(await getExpanded('__recent__', RECENT_NAME)).toBe(null);
+    expect(await getExpanded(GROUP_A, RECENT_NAME)).toBe(null);
+    expect(await getExpanded(GROUP_B, OTHER_NAME)).toBe(null);
+
+    expect(await dispatchRowAction('__recent__', RECENT_NAME, 'doubleClick')).toBe(true);
+    await waitForConnected('__recent__', RECENT_NAME);
+    await browser.waitUntil(async () => (await getExpanded('__recent__', RECENT_NAME)) === 'true', {
+      timeout: 30000,
+      timeoutMsg: '最近连接未展开',
+    });
+
+    expect(await getExpanded(GROUP_A, RECENT_NAME)).not.toBe('true');
+    expect(await getExpanded(GROUP_B, OTHER_NAME)).not.toBe('true');
+  });
+
+  it('从一个分组切换到另一个连接时始终只保留一个展开项', async () => {
+    expect(await dispatchRowAction(GROUP_A, RECENT_NAME, 'click')).toBe(true);
+    await browser.waitUntil(async () => (await getExpanded(GROUP_A, RECENT_NAME)) === 'true', {
+      timeout: 10000,
+      timeoutMsg: '分组内连接未展开',
+    });
+    expect(await getExpanded('__recent__', RECENT_NAME)).toBe('false');
+
+    expect(await dispatchRowAction(GROUP_B, OTHER_NAME, 'doubleClick')).toBe(true);
+    await waitForConnected(GROUP_B, OTHER_NAME);
+    expect(await dispatchRowAction(GROUP_B, OTHER_NAME, 'click')).toBe(true);
+    await browser.waitUntil(async () => (await getExpanded(GROUP_B, OTHER_NAME)) === 'true', {
+      timeout: 30000,
+      timeoutMsg: '其他分组连接未展开',
+    });
+
+    expect(await getExpanded('__recent__', RECENT_NAME)).toBe('false');
+    expect(await getExpanded(GROUP_A, RECENT_NAME)).toBe('false');
+    expect(await getExpanded(GROUP_B, OTHER_NAME)).toBe('true');
+  });
+});

--- a/e2e/wdio.conf.ts
+++ b/e2e/wdio.conf.ts
@@ -41,6 +41,7 @@ export const config: WebdriverIO.Config = {
     // Real-DB Host specs incl. the host contract matrix (was `pnpm e2e:db`)
     db: [
       './specs/connection-window.ts',
+      './specs/connection-navigator-expansion.ts',
       './specs/sql-query.ts',
       './specs/table-data.ts',
       './specs/table-filter.ts',

--- a/src/windows/connection/ConnectionNavigatorTree.tsx
+++ b/src/windows/connection/ConnectionNavigatorTree.tsx
@@ -179,24 +179,43 @@ export const ConnectionNavigatorTree = forwardRef<
 
   useEffect(() => {
     setExpandedConnections((prev) => {
-      let changed = false;
-      const next = new Set(prev);
-      for (const [connectionId, entry] of Object.entries(activeConnections)) {
-        if (entry?.status !== 'connected') continue;
-        const conn = connections.find((c) => c.id === connectionId);
-        if (!conn) continue;
-        for (const section of grouped) {
-          if (!section.connections.some((candidate) => candidate.id === connectionId)) continue;
-          const key = connectionExpandKey(section.group, connectionId);
-          if (!next.has(key)) {
-            next.add(key);
-            changed = true;
-          }
-        }
+      // A connection can be rendered in more than one section (for example
+      // in both "Recent" and its persisted group). Keep only one scoped key,
+      // otherwise expanding one occurrence also expands every shortcut row.
+      const validKeys = [...prev].filter((key) => {
+        const { sectionGroup, connectionId } = parseConnectionExpandKey(key);
+        if (activeConnections[connectionId]?.status !== 'connected') return false;
+        return grouped.some(
+          (section) =>
+            section.group === sectionGroup &&
+            section.connections.some((connection) => connection.id === connectionId),
+        );
+      });
+
+      if (validKeys.length > 0) {
+        const keep = validKeys[0];
+        return validKeys.length === 1 && prev.size === 1 && prev.has(keep) ? prev : new Set([keep]);
       }
-      return changed ? next : prev;
+
+      // Preserve an intentional collapsed state. The first connected session
+      // is expanded only when there is no prior expansion to retain.
+      if (prev.size > 0) return new Set();
+
+      const initialConnectionId =
+        activeConnectionId && activeConnections[activeConnectionId]?.status === 'connected'
+          ? activeConnectionId
+          : Object.entries(activeConnections).find(
+              ([, entry]) => entry?.status === 'connected',
+            )?.[0];
+      if (!initialConnectionId) return prev;
+
+      const initialSection = grouped.find((section) =>
+        section.connections.some((connection) => connection.id === initialConnectionId),
+      );
+      if (!initialSection) return prev;
+      return new Set([connectionExpandKey(initialSection.group, initialConnectionId)]);
     });
-  }, [activeConnections, connections, grouped]);
+  }, [activeConnectionId, activeConnections, connections, grouped]);
 
   const loadedConnectionsRef = useRef<Set<string>>(new Set());
   const prevConnectionIdsRef = useRef<Set<string>>(new Set());
@@ -291,14 +310,9 @@ export const ConnectionNavigatorTree = forwardRef<
     (connectionId: string, sectionGroup: string) => {
       const key = connectionExpandKey(sectionGroup, connectionId);
       setExpandedConnections((prev) => {
-        const next = new Set(prev);
-        if (next.has(key)) {
-          next.delete(key);
-        } else {
-          next.add(key);
-          onSelectConnection(connectionId);
-        }
-        return next;
+        if (prev.has(key)) return new Set();
+        onSelectConnection(connectionId);
+        return new Set([key]);
       });
     },
     [onSelectConnection],
@@ -477,10 +491,9 @@ export const ConnectionNavigatorTree = forwardRef<
       const entry = activeConnections[conn.id];
       if (entry?.status === 'connected') {
         const key = connectionExpandKey(sectionGroup, conn.id);
-        setExpandedConnections((prev) => {
-          if (prev.has(key)) return prev;
-          return new Set(prev).add(key);
-        });
+        setExpandedConnections((prev) =>
+          prev.size === 1 && prev.has(key) ? prev : new Set([key]),
+        );
       }
     },
     [onSelectConnection, activeConnections],

--- a/src/windows/connection/__tests__/ConnectionNavigatorTree.test.tsx
+++ b/src/windows/connection/__tests__/ConnectionNavigatorTree.test.tsx
@@ -258,6 +258,10 @@ vi.mock('../../../stores/connectionStore', () => {
         group: g,
         connections: connections.filter((c) => (c.group ?? '') === g),
       }));
+      const recent = connections.filter((connection) => connection.lastConnectedAt);
+      if (recent.length > 0) {
+        sections.unshift({ group: '__recent__', connections: recent });
+      }
       const known = new Set(groups);
       for (const c of connections) {
         const g = c.group ?? '';
@@ -1055,6 +1059,63 @@ describe('ConnectionNavigatorTree connection row interactions', () => {
     const idleChevron = connRow(view.container, 'Idle Conn').querySelector('button')!;
     fireEvent.click(idleChevron);
     expect(mockConnect).toHaveBeenCalledWith(expect.objectContaining({ id: 'cfg-idle' }));
+  });
+
+  it('scopes expansion to the clicked section and keeps only one connection expanded', async () => {
+    const recent = makeConn({
+      id: 'cfg-recent',
+      name: 'Recent Conn',
+      group: 'Group A',
+      lastConnectedAt: '2026-08-31T10:00:00Z',
+    });
+    const other = makeConn({ id: 'cfg-other', name: 'Other Conn', group: 'Group B' });
+    connectionsState.connections = [recent, other];
+    connectionsState.groups = ['Group A', 'Group B'];
+    activeConnectionsState.connections = {
+      'cfg-recent': {
+        status: 'connected',
+        dbSessionId: 'session-recent',
+        connectionId: 'cfg-recent',
+      },
+      'cfg-other': {
+        status: 'connected',
+        dbSessionId: 'session-other',
+        connectionId: 'cfg-other',
+      },
+    };
+
+    const { container } = render(
+      <ConnectionNavigatorTree {...baseProps} activeConnectionId={null} />,
+    );
+    await waitFor(() => {
+      expect(container.querySelector('[data-conn-group="__recent__"]')).not.toBeNull();
+      expect(container.querySelector('[data-conn-group="Group A"]')).not.toBeNull();
+    });
+
+    const expansion = (group: string, name: string) =>
+      container.querySelector<HTMLButtonElement>(
+        `[data-conn-group="${group}"][data-conn-name="${name}"] button`,
+      );
+    const recentShortcut = expansion('__recent__', 'Recent Conn')!;
+    const groupedRecent = expansion('Group A', 'Recent Conn')!;
+    const groupedOther = expansion('Group B', 'Other Conn')!;
+
+    expect(recentShortcut.getAttribute('aria-expanded')).toBe('true');
+    expect(groupedRecent.getAttribute('aria-expanded')).toBe('false');
+    expect(groupedOther.getAttribute('aria-expanded')).toBe('false');
+
+    fireEvent.click(expansion('Group A', 'Recent Conn')!);
+    await waitFor(() => {
+      expect(expansion('Group A', 'Recent Conn')?.getAttribute('aria-expanded')).toBe('true');
+      expect(expansion('__recent__', 'Recent Conn')?.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    fireEvent.click(expansion('Group B', 'Other Conn')!);
+    await waitFor(() => {
+      expect(expansion('Group B', 'Other Conn')?.getAttribute('aria-expanded')).toBe('true');
+      expect(expansion('Group A', 'Recent Conn')?.getAttribute('aria-expanded')).toBe('false');
+      expect(expansion('__recent__', 'Recent Conn')?.getAttribute('aria-expanded')).toBe('false');
+    });
   });
 });
 

--- a/src/windows/connection/navigator/NavigatorTreeRow.tsx
+++ b/src/windows/connection/navigator/NavigatorTreeRow.tsx
@@ -177,6 +177,7 @@ export function NavigatorTreeRow({
           <div
             data-conn-item
             data-conn-name={row.conn.name}
+            data-conn-group={row.sectionGroup}
             draggable
             onDragStart={(e) => handleDragStart(e, row.conn.id)}
             onDragOver={(e) => handleDragOver(e, row.conn.id)}


### PR DESCRIPTION
## Summary

- Scope connection tree expansion to the actual navigator section that was clicked.
- Keep at most one connection expanded at a time; expanding another connection collapses the previous one.
- Add unit and WebdriverIO E2E coverage for duplicate Recent/group rows and multi-group switching.

## Verification

- `pnpm test:unit`
- `pnpm typecheck`
- `pnpm e2e:skip-build -- --spec e2e/specs/connection-navigator-expansion.ts`
